### PR TITLE
Update Rust to 1.80.0

### DIFF
--- a/aarch64-lemmy-linux-gnu/Dockerfile
+++ b/aarch64-lemmy-linux-gnu/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.description="A cross toolchain from amd64 to aarc
 
 ARG BR2_VERSION="e091e31831122b60b084bd755e94df4dfe7188d2"
 ARG BR2_GIT_REPO="https://github.com/buildroot/buildroot.git"
-ARG RUST_VERSION=1.77
+ARG RUST_VERSION=1.80
 
 RUN apt-get update && \
    apt-get install -y build-essential binutils diffutils bzip2 perl unzip rsync cpio bc git file wget curl


### PR DESCRIPTION
The too-low version is causing lemmy's docker publish build to fail. This will need a new release after being merged also.

@raskyld 