### PR TITLE
feat: upgrade buildroot to fix arm64 -m64 issue

### DIFF
--- a/aarch64-lemmy-linux-gnu/Dockerfile
+++ b/aarch64-lemmy-linux-gnu/Dockerfile
@@ -9,16 +9,16 @@ LABEL org.opencontainers.image.source="https://github.com/raskyld/lemmy-cross-to
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.description="A cross toolchain from amd64 to aarch64 for the lemmy project"
 
-ARG BR2_VERSION="e091e31831122b60b084bd755e94df4dfe7188d2"
+ARG BR2_VERSION="053eb1a9840e5ab019d9aab348772491ce7afcd7"
 ARG BR2_GIT_REPO="https://github.com/buildroot/buildroot.git"
 ARG RUST_VERSION=1.91
 
 RUN apt-get update && \
-   apt-get install -y build-essential binutils diffutils bzip2 perl unzip rsync cpio bc git file wget curl
+    apt-get install -y build-essential binutils diffutils bzip2 perl unzip rsync cpio bc git file wget curl
 
 # We run as non-root user, your average SRE will thank me for that ;)
 RUN groupadd -g 10001 lemmy && \
-   useradd -m -u 10001 -g lemmy lemmy
+    useradd -m -u 10001 -g lemmy lemmy
 
 USER 10001:10001
 WORKDIR /home/lemmy

--- a/aarch64-lemmy-linux-gnu/br_config
+++ b/aarch64-lemmy-linux-gnu/br_config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Buildroot -ge091e318 Configuration
+# Buildroot 2025.11-14-g053eb1a984 Configuration
 #
 BR2_HAVE_DOT_CONFIG=y
 BR2_HOST_GCC_AT_LEAST_4_9=y
@@ -11,6 +11,7 @@ BR2_HOST_GCC_AT_LEAST_8=y
 BR2_HOST_GCC_AT_LEAST_9=y
 BR2_HOST_GCC_AT_LEAST_10=y
 BR2_HOST_GCC_AT_LEAST_11=y
+BR2_HOST_GCC_AT_LEAST_12=y
 
 #
 # Target options
@@ -24,6 +25,7 @@ BR2_USE_MMU=y
 BR2_aarch64=y
 # BR2_aarch64_be is not set
 # BR2_i386 is not set
+# BR2_loongarch64 is not set
 # BR2_m68k is not set
 # BR2_microblazeel is not set
 # BR2_microblazebe is not set
@@ -31,7 +33,6 @@ BR2_aarch64=y
 # BR2_mipsel is not set
 # BR2_mips64 is not set
 # BR2_mips64el is not set
-# BR2_nios2 is not set
 # BR2_or1k is not set
 # BR2_powerpc is not set
 # BR2_powerpc64 is not set
@@ -97,6 +98,7 @@ BR2_cortex_a53=y
 # BR2_cortex_a75_a55 is not set
 # BR2_cortex_a76 is not set
 # BR2_cortex_a76_a55 is not set
+# BR2_cortex_a78 is not set
 # BR2_neoverse_n1 is not set
 # BR2_tsv110 is not set
 
@@ -104,6 +106,17 @@ BR2_cortex_a53=y
 # armv8.4a cores
 #
 # BR2_saphira is not set
+
+#
+# armv9.0a cores
+#
+# BR2_cortex_a710 is not set
+# BR2_neoverse_n2 is not set
+
+#
+# armv9.2a cores
+#
+# BR2_cortex_a720 is not set
 # BR2_ARM_FPU_VFPV2 is not set
 # BR2_ARM_FPU_VFPV3 is not set
 # BR2_ARM_FPU_VFPV3D16 is not set
@@ -111,6 +124,7 @@ BR2_cortex_a53=y
 # BR2_ARM_FPU_VFPV4D16 is not set
 BR2_ARM_FPU_FP_ARMV8=y
 BR2_ARM64_PAGE_SIZE_4K=y
+# BR2_ARM64_PAGE_SIZE_16K is not set
 # BR2_ARM64_PAGE_SIZE_64K is not set
 BR2_ARM64_PAGE_SIZE="4K"
 BR2_BINFMT_ELF=y
@@ -135,19 +149,17 @@ BR2_TOOLCHAIN_BUILDROOT_LIBC="glibc"
 #
 # Kernel Header Options
 #
-# BR2_KERNEL_HEADERS_4_14 is not set
-# BR2_KERNEL_HEADERS_4_19 is not set
-# BR2_KERNEL_HEADERS_5_4 is not set
 # BR2_KERNEL_HEADERS_5_10 is not set
 # BR2_KERNEL_HEADERS_5_15 is not set
 # BR2_KERNEL_HEADERS_6_1 is not set
-# BR2_KERNEL_HEADERS_6_5 is not set
 BR2_KERNEL_HEADERS_6_6=y
+# BR2_KERNEL_HEADERS_6_12 is not set
+# BR2_KERNEL_HEADERS_6_17 is not set
+# BR2_KERNEL_HEADERS_6_18 is not set
 # BR2_KERNEL_HEADERS_VERSION is not set
 # BR2_KERNEL_HEADERS_CUSTOM_TARBALL is not set
 # BR2_KERNEL_HEADERS_CUSTOM_GIT is not set
-BR2_KERNEL_HEADERS_LATEST=y
-BR2_DEFAULT_KERNEL_HEADERS="6.6"
+BR2_DEFAULT_KERNEL_HEADERS="6.6.119"
 BR2_PACKAGE_LINUX_HEADERS=y
 BR2_PACKAGE_MUSL_ARCH_SUPPORTS=y
 BR2_PACKAGE_MUSL_SUPPORTS=y
@@ -167,20 +179,20 @@ BR2_PACKAGE_GLIBC=y
 # Binutils Options
 #
 BR2_PACKAGE_HOST_BINUTILS_SUPPORTS_CFI=y
-# BR2_BINUTILS_VERSION_2_39_X is not set
-BR2_BINUTILS_VERSION_2_40_X=y
-# BR2_BINUTILS_VERSION_2_41_X is not set
-BR2_BINUTILS_VERSION="2.40"
+# BR2_BINUTILS_VERSION_2_42_X is not set
+# BR2_BINUTILS_VERSION_2_43_X is not set
+BR2_BINUTILS_VERSION_2_44_X=y
+BR2_BINUTILS_VERSION="2.44"
 # BR2_BINUTILS_GPROFNG is not set
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS=""
 
 #
 # GCC Options
 #
-# BR2_GCC_VERSION_11_X is not set
-BR2_GCC_VERSION_12_X=y
 # BR2_GCC_VERSION_13_X is not set
-BR2_GCC_VERSION="12.3.0"
+BR2_GCC_VERSION_14_X=y
+# BR2_GCC_VERSION_15_X is not set
+BR2_GCC_VERSION="14.3.0"
 BR2_EXTRA_GCC_CONFIG_OPTIONS=""
 # BR2_TOOLCHAIN_BUILDROOT_CXX is not set
 # BR2_TOOLCHAIN_BUILDROOT_FORTRAN is not set
@@ -281,7 +293,6 @@ BR2_TOOLCHAIN_HEADERS_AT_LEAST_6_3=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_6_4=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_6_5=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_6_6=y
-BR2_TOOLCHAIN_HEADERS_LATEST=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST="6.6"
 BR2_TOOLCHAIN_GCC_AT_LEAST_4_3=y
 BR2_TOOLCHAIN_GCC_AT_LEAST_4_4=y
@@ -298,7 +309,9 @@ BR2_TOOLCHAIN_GCC_AT_LEAST_9=y
 BR2_TOOLCHAIN_GCC_AT_LEAST_10=y
 BR2_TOOLCHAIN_GCC_AT_LEAST_11=y
 BR2_TOOLCHAIN_GCC_AT_LEAST_12=y
-BR2_TOOLCHAIN_GCC_AT_LEAST="12"
+BR2_TOOLCHAIN_GCC_AT_LEAST_13=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_14=y
+BR2_TOOLCHAIN_GCC_AT_LEAST="14"
 BR2_TOOLCHAIN_HAS_MNAN_OPTION=y
 BR2_TOOLCHAIN_HAS_SYNC_1=y
 BR2_TOOLCHAIN_HAS_SYNC_2=y
@@ -308,12 +321,18 @@ BR2_TOOLCHAIN_HAS_LIBATOMIC=y
 BR2_TOOLCHAIN_HAS_ATOMIC=y
 
 #
+# Bare metal toolchain
+#
+# BR2_TOOLCHAIN_BARE_METAL_BUILDROOT is not set
+
+#
 # Build options
 #
 
 #
 # Commands
 #
+BR2_CURL="curl -q --ftp-pasv --retry 3 --connect-timeout 10"
 BR2_WGET="wget --passive-ftp -nd -t 3"
 BR2_SVN="svn --non-interactive"
 BR2_BZR="bzr"
@@ -327,6 +346,7 @@ BR2_ZCAT="gzip -d -c"
 BR2_BZCAT="bzcat"
 BR2_XZCAT="xzcat"
 BR2_LZCAT="lzip -d -c"
+BR2_ZSTDCAT="zstdcat"
 BR2_TAR_OPTIONS=""
 BR2_DEFCONFIG="$(CONFIG_DIR)/defconfig"
 BR2_DL_DIR="$(TOPDIR)/dl"
@@ -369,10 +389,7 @@ BR2_GLOBAL_PATCH_DIR=""
 # Advanced
 #
 # BR2_FORCE_HOST_BUILD is not set
-
-#
-# Forcing all downloads to have a valid hash needs a global patch and hash directory
-#
+# BR2_DOWNLOAD_FORCE_CHECK_HASHES is not set
 # BR2_REPRODUCIBLE is not set
 # BR2_PER_PACKAGE_DIRECTORIES is not set
 
@@ -405,10 +422,21 @@ BR2_TARGET_GENERIC_ISSUE="Welcome to Lemmy cross-toolchain!"
 BR2_TARGET_GENERIC_PASSWD_SHA256=y
 # BR2_TARGET_GENERIC_PASSWD_SHA512 is not set
 BR2_TARGET_GENERIC_PASSWD_METHOD="sha-256"
+
+#
+# General purpose
+#
 BR2_INIT_BUSYBOX=y
 # BR2_INIT_SYSV is not set
 # BR2_INIT_OPENRC is not set
 # BR2_INIT_SYSTEMD is not set
+
+#
+# Special purpose (read help)
+#
+# BR2_INIT_CATATONIT is not set
+# BR2_INIT_TINI is not set
+# BR2_INIT_TINYINIT is not set
 # BR2_INIT_NONE is not set
 # BR2_ROOTFS_DEVICE_CREATION_STATIC is not set
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_DEVTMPFS=y
@@ -464,6 +492,7 @@ BR2_PACKAGE_BUSYBOX_CONFIG="package/busybox/busybox.config"
 BR2_PACKAGE_BUSYBOX_CONFIG_FRAGMENT_FILES=""
 # BR2_PACKAGE_BUSYBOX_SHOW_OTHERS is not set
 # BR2_PACKAGE_BUSYBOX_INDIVIDUAL_BINARIES is not set
+# BR2_PACKAGE_BUSYBOX_HTTPD is not set
 # BR2_PACKAGE_BUSYBOX_WATCHDOG is not set
 BR2_PACKAGE_SKELETON=y
 BR2_PACKAGE_HAS_SKELETON=y
@@ -508,7 +537,7 @@ BR2_PACKAGE_FFMPEG_ARCH_SUPPORTS=y
 BR2_PACKAGE_KODI_ARCH_SUPPORTS=y
 
 #
-# kodi needs python3 w/ .py modules, a uClibc or glibc toolchain w/ C++, threads, wchar, dynamic library, gcc >= 9.x
+# kodi needs python3 w/ .py modules, a uClibc or glibc toolchain w/ C++, threads, wchar, dynamic library, gcc >= 9.x, host gcc >= 9.x
 #
 
 #
@@ -520,7 +549,6 @@ BR2_PACKAGE_KODI_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_LAME is not set
 # BR2_PACKAGE_MADPLAY is not set
-# BR2_PACKAGE_MIMIC is not set
 # BR2_PACKAGE_MINIMODEM is not set
 
 #
@@ -537,7 +565,7 @@ BR2_PACKAGE_KODI_ARCH_SUPPORTS=y
 # BR2_PACKAGE_MOTION is not set
 
 #
-# mpd needs a toolchain w/ C++, threads, wchar, gcc >= 8, host gcc >= 8
+# mpd needs a toolchain w/ C++, threads, wchar, host-gcc 10, gcc 12, headers 5.6
 #
 # BR2_PACKAGE_MPD_MPC is not set
 # BR2_PACKAGE_MPG123 is not set
@@ -619,6 +647,10 @@ BR2_PACKAGE_PULSEAUDIO_HAS_ATOMIC=y
 # Debugging, profiling and benchmark
 #
 # BR2_PACKAGE_BABELTRACE2 is not set
+
+#
+# bcc needs a glibc toolchain, C++, wchar, threads, dynamic libs, gcc >= 7, host gcc >= 7
+#
 # BR2_PACKAGE_BLKTRACE is not set
 
 #
@@ -626,6 +658,11 @@ BR2_PACKAGE_PULSEAUDIO_HAS_ATOMIC=y
 #
 BR2_PACKAGE_BPFTOOL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_BPFTOOL is not set
+BR2_PACKAGE_BPFTRACE_ARCH_SUPPORTS=y
+
+#
+# bpftrace needs a glibc toolchain w/ C++, gcc >= 7, host gcc >= 7, kernel headers >= 4.13
+#
 # BR2_PACKAGE_CACHE_CALIBRATOR is not set
 
 #
@@ -664,15 +701,16 @@ BR2_PACKAGE_GDB_ARCH_SUPPORTS=y
 BR2_PACKAGE_GOOGLE_BREAKPAD_ARCH_SUPPORTS=y
 
 #
-# google-breakpad requires a glibc or uClibc toolchain w/ wchar, thread, C++, gcc >= 4.8
+# google-breakpad requires a glibc toolchain w/ wchar, threads, C++, gcc >= 7
 #
 # BR2_PACKAGE_HYPERFINE is not set
 # BR2_PACKAGE_IOZONE is not set
 BR2_PACKAGE_KEXEC_ARCH_SUPPORTS=y
 # BR2_PACKAGE_KEXEC is not set
 # BR2_PACKAGE_KMEMD is not set
-# BR2_PACKAGE_LATENCYTOP is not set
 # BR2_PACKAGE_LIBBPF is not set
+# BR2_PACKAGE_LIBTRACEEVENT is not set
+# BR2_PACKAGE_LIBTRACEFS is not set
 # BR2_PACKAGE_LMBENCH is not set
 BR2_PACKAGE_LTP_TESTSUITE_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LTP_TESTSUITE is not set
@@ -706,7 +744,7 @@ BR2_PACKAGE_PERFTEST_ARCH_SUPPORTS=y
 # BR2_PACKAGE_PERFTEST is not set
 
 #
-# piglit needs a glibc or musl toolchain w/ C++
+# piglit needs a glibc or musl toolchain w/ C++, gcc >= 9, host gcc >= 9
 #
 BR2_PACKAGE_PLY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_PLY is not set
@@ -714,8 +752,6 @@ BR2_PACKAGE_PLY_ARCH_SUPPORTS=y
 BR2_PACKAGE_PTM2HUMAN_ARCH_SUPPORTS=y
 # BR2_PACKAGE_PTM2HUMAN is not set
 # BR2_PACKAGE_PV is not set
-# BR2_PACKAGE_RAMSMP is not set
-# BR2_PACKAGE_RAMSPEED is not set
 # BR2_PACKAGE_RT_TESTS is not set
 
 #
@@ -723,7 +759,7 @@ BR2_PACKAGE_PTM2HUMAN_ARCH_SUPPORTS=y
 #
 
 #
-# sentry-native needs a glibc toolchain with w/ wchar, thread, C++, gcc >= 4.8
+# sentry-native needs a glibc toolchain with w/ wchar, threads, C++, gcc >= 7
 #
 
 #
@@ -735,12 +771,19 @@ BR2_PACKAGE_PTM2HUMAN_ARCH_SUPPORTS=y
 # BR2_PACKAGE_STRESS_NG is not set
 
 #
-# sysdig needs a glibc toolchain w/ C++, threads, gcc >= 5, dynamic library, a Linux kernel, and luajit or lua 5.1 to be built
+# sysdig needs a glibc toolchain w/ C++, threads, gcc >= 8, dynamic library, a Linux kernel, and luajit or lua 5.1 to be built
+#
+
+#
+# sysprof needs a toolchain w/ dynamic library, wchar, threads, C++, gcc >= 7, headers >= 5.12
+#
+
+#
+# tbtools needs udev /dev management w/ glibc toolchain
 #
 # BR2_PACKAGE_TCF_AGENT is not set
 BR2_PACKAGE_TCF_AGENT_ARCH="a64"
 BR2_PACKAGE_TCF_AGENT_ARCH_SUPPORTS=y
-# BR2_PACKAGE_TINYMEMBENCH is not set
 # BR2_PACKAGE_TRACE_CMD is not set
 BR2_PACKAGE_TRINITY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_TRINITY is not set
@@ -758,7 +801,6 @@ BR2_PACKAGE_VALGRIND_ARCH_SUPPORTS=y
 # BR2_PACKAGE_AVOCADO is not set
 # BR2_PACKAGE_BINUTILS is not set
 # BR2_PACKAGE_BITWISE is not set
-# BR2_PACKAGE_BSDIFF is not set
 # BR2_PACKAGE_CHECK is not set
 BR2_PACKAGE_CMAKE_ARCH_SUPPORTS=y
 
@@ -776,6 +818,7 @@ BR2_PACKAGE_CMAKE_ARCH_SUPPORTS=y
 #
 # cxxtest needs a toolchain w/ C++ support
 #
+# BR2_PACKAGE_FD is not set
 # BR2_PACKAGE_FLEX is not set
 # BR2_PACKAGE_GETTEXT is not set
 BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
@@ -796,6 +839,7 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # BR2_PACKAGE_PKGCONF is not set
 # BR2_PACKAGE_RIPGREP is not set
 # BR2_PACKAGE_SUBVERSION is not set
+# BR2_PACKAGE_TIG is not set
 # BR2_PACKAGE_TREE is not set
 # BR2_PACKAGE_UNIFDEF is not set
 
@@ -803,11 +847,11 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # Filesystem and flash utilities
 #
 # BR2_PACKAGE_ABOOTIMG is not set
+# BR2_PACKAGE_AUTOFS is not set
 
 #
-# aufs-util needs a linux kernel and a toolchain w/ threads
+# bmap-writer needs a toolchain w/ C++, wchar
 #
-# BR2_PACKAGE_AUTOFS is not set
 # BR2_PACKAGE_BTRFS_PROGS is not set
 # BR2_PACKAGE_CIFS_UTILS is not set
 # BR2_PACKAGE_CPIO is not set
@@ -831,7 +875,6 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # BR2_PACKAGE_FWUP is not set
 # BR2_PACKAGE_GENEXT2FS is not set
 # BR2_PACKAGE_GENPART is not set
-# BR2_PACKAGE_GENROMFS is not set
 # BR2_PACKAGE_GOCRYPTFS is not set
 # BR2_PACKAGE_IMX_USB_LOADER is not set
 # BR2_PACKAGE_MMC_UTILS is not set
@@ -844,6 +887,7 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # BR2_PACKAGE_SQUASHFS is not set
 # BR2_PACKAGE_SSHFS is not set
 # BR2_PACKAGE_UDFTOOLS is not set
+# BR2_PACKAGE_UFS_UTILS is not set
 # BR2_PACKAGE_UNIONFS is not set
 
 #
@@ -863,7 +907,6 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # Cursors
 #
 # BR2_PACKAGE_COMIX_CURSORS is not set
-# BR2_PACKAGE_OBSIDIAN_CURSORS is not set
 
 #
 # Fonts
@@ -889,10 +932,6 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # BR2_PACKAGE_SOUND_THEME_FREEDESKTOP is not set
 
 #
-# Themes
-#
-
-#
 # Games
 #
 # BR2_PACKAGE_ASCII_INVADERS is not set
@@ -901,7 +940,6 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 #
 # flare-engine needs a toolchain w/ C++, dynamic library
 #
-# BR2_PACKAGE_FROTZ is not set
 
 #
 # gnuchess needs a toolchain w/ C++, threads
@@ -910,14 +948,14 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # BR2_PACKAGE_LTRIS is not set
 
 #
-# minetest needs a toolchain w/ C++, gcc >= 5.1, threads
+# minetest needs a toolchain w/ C++, gcc >= 9, threads
 #
 # BR2_PACKAGE_OPENTYRIAN is not set
 # BR2_PACKAGE_PRBOOM is not set
 # BR2_PACKAGE_SL is not set
 
 #
-# solarus needs OpenGL and a toolchain w/ C++, gcc >= 4.9, NPTL, dynamic library, and luajit or lua 5.1
+# solarus needs OpenGL and a toolchain w/ C++, gcc >= 9, NPTL, dynamic library, and luajit or lua 5.1
 #
 
 #
@@ -934,12 +972,29 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 #
 
 #
-# cage needs udev, EGL w/ Wayland backend and OpenGL ES support
+# cage needs udev, EGL and OpenGL ES support
 #
 
 #
 # cog needs wpewebkit and a toolchain w/ threads
 #
+
+#
+# flutter packages need flutter-engine
+#
+
+#
+# flutter-pi needs a glibc toolchain w/ wchar, C++, gcc >= 5, dynamic library, host gcc >= 5
+#
+
+#
+# flutter-pi needs an OpenGL or OpenGLES backend
+#
+
+#
+# flutter-pi needs GBM, systemd, and udev
+#
+# BR2_PACKAGE_FOOT is not set
 # BR2_PACKAGE_FSWEBCAM is not set
 # BR2_PACKAGE_GHOSTSCRIPT is not set
 
@@ -951,6 +1006,18 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # glslsandbox-player needs openGL ES and EGL driver
 #
 # BR2_PACKAGE_GNUPLOT is not set
+
+#
+# igt-gpu-tools needs udev /dev management and toolchain w/ NPTL, wchar, dynamic library, locale, headers >= 4.11
+#
+
+#
+# ivi-homescreen needs a glibc toolchain w/ wchar, C++, gcc >= 8, dynamic library, host gcc >= 5
+#
+
+#
+# ivi-homescreen needs an OpenGL or OpenGLES backend
+#
 # BR2_PACKAGE_JHEAD is not set
 
 #
@@ -960,22 +1027,17 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 #
 # libva-utils needs a toolchain w/ C++, threads, dynamic library
 #
-BR2_PACKAGE_MIDORI_ARCH_SUPPORTS=y
-
-#
-# midori needs a glibc toolchain w/ C++, wchar, threads, dynamic library, gcc >= 7, host gcc >= 8
-#
-
-#
-# midori needs libgtk3 w/ X11 or wayland backend
-#
 BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 # BR2_PACKAGE_NETSURF is not set
 # BR2_PACKAGE_PNGQUANT is not set
 # BR2_PACKAGE_RRDTOOL is not set
 
 #
-# spirv-tools needs a toolchain w/ C++, gcc >= 7
+# spirv-translator needs a toolchain w/ wchar, threads, C++, gcc >= 7, dynamic library, host gcc >= 7
+#
+
+#
+# spirv-tools needs a toolchain w/ C++, dynamic library, gcc >= 8
 #
 
 #
@@ -983,7 +1045,7 @@ BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 #
 
 #
-# sway needs systemd, udev, EGL w/ Wayland backend and OpenGL ES support
+# sway needs systemd, udev, EGL and OpenGL ES support
 #
 
 #
@@ -992,9 +1054,13 @@ BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 # BR2_PACKAGE_SWAYBG is not set
 
 #
-# tesseract-ocr needs a toolchain w/ threads, C++, gcc >= 7, dynamic library, wchar
+# tesseract-ocr needs a toolchain w/ threads, C++, gcc >= 8, dynamic library, wchar
 #
 # BR2_PACKAGE_TINIFIER is not set
+
+#
+# wmenu needs a toolchain w/ wchar, threads, C++, dynamic library, gcc >= 4.9
+#
 
 #
 # Graphic libraries
@@ -1002,10 +1068,6 @@ BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 
 #
 # cegui needs a toolchain w/ C++, threads, dynamic library, wchar, gcc >= 5
-#
-
-#
-# directfb needs a glibc or uClibc toolchain w/ C++, NPTL, gcc >= 4.5, dynamic library
 #
 
 #
@@ -1021,27 +1083,11 @@ BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 # BR2_PACKAGE_FBV is not set
 
 #
-# flutter-gallery needs flutter-engine
-#
-
-#
-# flutter-pi needs flutter-engine
-#
-
-#
-# flutter-pi needs GBM, systemd, and udev
-#
-
-#
 # freerdp needs a toolchain w/ wchar, dynamic library, threads, C++
 #
 # BR2_PACKAGE_GRAPHICSMAGICK is not set
 # BR2_PACKAGE_IMAGEMAGICK is not set
 # BR2_PACKAGE_LIBGLVND is not set
-
-#
-# linux-fusion needs a Linux kernel to be built
-#
 
 #
 # mesa3d needs a toolchain w/ gcc >=8, C++, NPTL, dynamic library
@@ -1061,10 +1107,17 @@ BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 #
 # spirv-headers needs a toolchain w/ C++
 #
-# BR2_PACKAGE_VULKAN_HEADERS is not set
+
+#
+# vulkan-headers needs a toolchain w/ C++
+#
 
 #
 # vulkan-loader needs a toolchain w/ C++, dynamic library, threads
+#
+
+#
+# Vulkan-SDK needs toolchain w/ C++, dynamic library
 #
 
 #
@@ -1103,11 +1156,23 @@ BR2_PACKAGE_QT6_ARCH_SUPPORTS=y
 #
 
 #
+# pcmanfm a toolchain w/ wchar, threads, C++, gcc >= 4.9
+#
+
+#
+# pcmanfm needs X.org with an OpenGL backend
+#
+
+#
 # vte needs a uClibc or glibc toolchain w/ wchar, threads, C++, gcc >= 10
 #
 
 #
-# vte needs an OpenGL or an OpenGL-EGL/wayland backend
+# vte needs an OpenGL or an OpenGL-EGL backend
+#
+
+#
+# yad needs libgtk3 w/ X11 backend
 #
 # BR2_PACKAGE_XKEYBOARD_CONFIG is not set
 
@@ -1123,16 +1188,22 @@ BR2_PACKAGE_QT6_ARCH_SUPPORTS=y
 # BR2_PACKAGE_BRCMFMAC_SDIO_FIRMWARE_RPI is not set
 # BR2_PACKAGE_LINUX_FIRMWARE is not set
 # BR2_PACKAGE_MURATA_CYW_FW is not set
+# BR2_PACKAGE_NXP_BT_WIFI_FIRMWARE is not set
 # BR2_PACKAGE_ODROIDC2_FIRMWARE is not set
+# BR2_PACKAGE_PANEL_MIPI_DBI_FIRMWARE is not set
 # BR2_PACKAGE_QCOM_DB410C_FIRMWARE is not set
+# BR2_PACKAGE_QORIQ_DDR_PHY_BINARY is not set
+# BR2_PACKAGE_QORIQ_FIRMWARE_INPHI is not set
 # BR2_PACKAGE_QORIQ_FM_UCODE is not set
+# BR2_PACKAGE_QORIQ_MC_BINARY is not set
+# BR2_PACKAGE_QORIQ_MC_UTILS is not set
 # BR2_PACKAGE_RCW_SMARC_SAL28 is not set
 # BR2_PACKAGE_RPI_FIRMWARE is not set
 # BR2_PACKAGE_UX500_FIRMWARE is not set
-# BR2_PACKAGE_VERSAL_FIRMWARE is not set
 # BR2_PACKAGE_WILC1000_FIRMWARE is not set
 # BR2_PACKAGE_WILC3000_FIRMWARE is not set
 # BR2_PACKAGE_WILINK_BT_FIRMWARE is not set
+# BR2_PACKAGE_XILINX_FPGAUTIL is not set
 # BR2_PACKAGE_ZD1211_FIRMWARE is not set
 # BR2_PACKAGE_18XX_TI_UTILS is not set
 # BR2_PACKAGE_ACPICA is not set
@@ -1152,6 +1223,7 @@ BR2_PACKAGE_QT6_ARCH_SUPPORTS=y
 #
 # bcache-tools needs udev /dev management
 #
+# BR2_PACKAGE_BFSCRIPTS is not set
 
 #
 # brickd needs udev /dev management, a toolchain w/ threads, wchar
@@ -1198,8 +1270,6 @@ BR2_PACKAGE_CPUBURN_ARM_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_DTV_SCAN_TABLES is not set
 # BR2_PACKAGE_DUMP1090 is not set
-# BR2_PACKAGE_DVB_APPS is not set
-# BR2_PACKAGE_DVBSNOOP is not set
 
 #
 # edid-decode needs a toolchain w/ C++, gcc >= 4.7
@@ -1210,18 +1280,26 @@ BR2_PACKAGE_CPUBURN_ARM_ARCH_SUPPORTS=y
 #
 
 #
+# espflash needs udev /dev management
+#
+
+#
 # eudev needs eudev /dev management
 #
 # BR2_PACKAGE_EVEMU is not set
 # BR2_PACKAGE_EVTEST is not set
-# BR2_PACKAGE_FAN_CTRL is not set
-# BR2_PACKAGE_FCONFIG is not set
 BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_FLASHROM is not set
 # BR2_PACKAGE_FMTOOLS is not set
 # BR2_PACKAGE_FREEIPMI is not set
 # BR2_PACKAGE_FREESCALE_IMX is not set
+# BR2_PACKAGE_FWUPD is not set
+# BR2_PACKAGE_FWUPD_EFI is not set
 # BR2_PACKAGE_FXLOAD is not set
+
+#
+# gcnano-binaries needs a Linux kernel to be built
+#
 # BR2_PACKAGE_GPM is not set
 # BR2_PACKAGE_GPSD is not set
 
@@ -1233,6 +1311,7 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HWDATA is not set
 # BR2_PACKAGE_HWLOC is not set
 # BR2_PACKAGE_INPUT_EVENT_DAEMON is not set
+# BR2_PACKAGE_IOTOOLS is not set
 # BR2_PACKAGE_IPMITOOL is not set
 # BR2_PACKAGE_IRDA_UTILS is not set
 # BR2_PACKAGE_KBD is not set
@@ -1245,7 +1324,10 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 #
 # libiec61850 needs a toolchain w/ C++, threads, dynamic library
 #
-# BR2_PACKAGE_LIBMANETTE is not set
+
+#
+# libmanette needs a toolchain w/ wchar, NPTL threads, gcc >= 4.9, headers >= 4.16, udev
+#
 # BR2_PACKAGE_LIBUBOOTENV is not set
 # BR2_PACKAGE_LIBUIO is not set
 
@@ -1282,16 +1364,17 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_MEMTOOL is not set
 # BR2_PACKAGE_MHZ is not set
 # BR2_PACKAGE_MINICOM is not set
+# BR2_PACKAGE_MXT_APP is not set
 # BR2_PACKAGE_NANOCOM is not set
 # BR2_PACKAGE_NEARD is not set
 # BR2_PACKAGE_NVIDIA_MODPROBE is not set
 # BR2_PACKAGE_NVIDIA_PERSISTENCED is not set
 # BR2_PACKAGE_NVME is not set
-# BR2_PACKAGE_OFONO is not set
 
 #
-# ola needs a toolchain w/ C++, threads, dynamic library, gcc >= 4.8
+# nxp-mwifiex needs a Linux kernel to be built
 #
+# BR2_PACKAGE_OFONO is not set
 # BR2_PACKAGE_OPEN2300 is not set
 
 #
@@ -1303,12 +1386,20 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_PCIUTILS is not set
 # BR2_PACKAGE_PDBG is not set
 # BR2_PACKAGE_PICOCOM is not set
+
+#
+# picotool needs a toolchain w/ C++, threads, gcc >= 4.9
+#
 # BR2_PACKAGE_PIGPIO is not set
 
 #
 # powertop needs a toolchain w/ C++, threads, wchar
 #
 # BR2_PACKAGE_PPS_TOOLS is not set
+
+#
+# pulseview needs a toolchain w/ locale, wchar, threads, dynamic library, C++, gcc >= 7, host gcc >= 5
+#
 # BR2_PACKAGE_QORIQ_CADENCE_DP_FIRMWARE is not set
 # BR2_PACKAGE_RASPI_GPIO is not set
 # BR2_PACKAGE_RDMA_CORE is not set
@@ -1366,6 +1457,7 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 #
 # rl8822cs needs a Linux kernel to be built
 #
+# BR2_PACKAGE_SANE_AIRSCAN is not set
 # BR2_PACKAGE_SANE_BACKENDS is not set
 # BR2_PACKAGE_SDPARM is not set
 BR2_PACKAGE_SEDUTIL_ARCH_SUPPORTS=y
@@ -1388,20 +1480,21 @@ BR2_PACKAGE_SEDUTIL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_STM32FLASH is not set
 # BR2_PACKAGE_SUNXI_MALI_UTGARD is not set
 # BR2_PACKAGE_SYSSTAT is not set
-
-#
-# targetcli-fb depends on Python
-#
 # BR2_PACKAGE_TI_UIM is not set
 # BR2_PACKAGE_TI_UTILS is not set
-# BR2_PACKAGE_TIO is not set
+
+#
+# tio needs lua (but not luajit)
+#
 # BR2_PACKAGE_TRIGGERHAPPY is not set
+# BR2_PACKAGE_UBOOT_BOOTCOUNT is not set
 # BR2_PACKAGE_UBOOT_TOOLS is not set
 # BR2_PACKAGE_UBUS is not set
 
 #
 # udisks needs udev /dev management
 #
+# BR2_PACKAGE_UEFISETTINGS is not set
 # BR2_PACKAGE_UHUBCTL is not set
 # BR2_PACKAGE_UMTPRD is not set
 
@@ -1416,13 +1509,16 @@ BR2_PACKAGE_SEDUTIL_ARCH_SUPPORTS=y
 #
 
 #
+# usbip needs udev /dev management
+#
+
+#
 # usbmount requires udev to be enabled
 #
 
 #
 # usbutils needs udev /dev management and toolchain w/ threads, gcc >= 4.9
 #
-# BR2_PACKAGE_W_SCAN is not set
 
 #
 # wilc kernel module needs a Linux kernel to be built
@@ -1438,6 +1534,7 @@ BR2_PACKAGE_SEDUTIL_ARCH_SUPPORTS=y
 # Interpreter languages and scripting
 #
 # BR2_PACKAGE_4TH is not set
+# BR2_PACKAGE_CHICKEN is not set
 # BR2_PACKAGE_ENSCRIPT is not set
 BR2_PACKAGE_HOST_ERLANG_ARCH_SUPPORTS=y
 BR2_PACKAGE_ERLANG_ARCH_SUPPORTS=y
@@ -1463,11 +1560,12 @@ BR2_PACKAGE_MONO_ARCH_SUPPORTS=y
 BR2_PACKAGE_NODEJS_ARCH_SUPPORTS=y
 
 #
-# nodejs needs a toolchain w/ C++, dynamic library, NPTL, gcc >= 11, wchar, host gcc >= 11
+# nodejs needs a toolchain w/ C++, dynamic library, NPTL, gcc >= 10, wchar, host gcc >= 10
 #
+BR2_PACKAGE_PROVIDES_NODEJS="nodejs-src"
 
 #
-# octave needs a toolchain w/ C++ and fortran, gcc >= 4.8
+# octave needs a toolchain w/ C++ and fortran, gcc >= 7
 #
 BR2_PACKAGE_HOST_OPENJDK_BIN_ARCH_SUPPORTS=y
 BR2_PACKAGE_OPENJDK_ARCH_SUPPORTS=y
@@ -1485,6 +1583,8 @@ BR2_PACKAGE_PHP_ARCH_SUPPORTS=y
 # BR2_PACKAGE_PYTHON3 is not set
 # BR2_PACKAGE_QUICKJS is not set
 # BR2_PACKAGE_RUBY is not set
+BR2_PACKAGE_SWIPL_ARCH_SUPPORTS=y
+# BR2_PACKAGE_SWIPL is not set
 # BR2_PACKAGE_TCL is not set
 
 #
@@ -1497,7 +1597,7 @@ BR2_PACKAGE_PHP_ARCH_SUPPORTS=y
 # BR2_PACKAGE_ALSA_LIB is not set
 
 #
-# alure needs a toolchain w/ C++, gcc >= 4.9, NPTL, wchar
+# alure needs a toolchain w/ C++, gcc >= 9, NPTL, wchar
 #
 # BR2_PACKAGE_AUBIO is not set
 # BR2_PACKAGE_BCG729 is not set
@@ -1510,6 +1610,11 @@ BR2_PACKAGE_FDK_AAC_ARCH_SUPPORTS=y
 #
 # fdk-aac needs a toolchain w/ C++
 #
+BR2_PACKAGE_GTKIOSTREAM_ARCH_SUPPORTS=y
+
+#
+# gtkiostream needs a toolchain w/ C++, threads
+#
 # BR2_PACKAGE_LIBAO is not set
 # BR2_PACKAGE_LIBBROADVOICE is not set
 # BR2_PACKAGE_LIBCANBERRA is not set
@@ -1520,7 +1625,6 @@ BR2_PACKAGE_FDK_AAC_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBCODEC2 is not set
 # BR2_PACKAGE_LIBCUE is not set
 # BR2_PACKAGE_LIBCUEFILE is not set
-# BR2_PACKAGE_LIBEBUR128 is not set
 # BR2_PACKAGE_LIBG7221 is not set
 # BR2_PACKAGE_LIBGSM is not set
 # BR2_PACKAGE_LIBID3TAG is not set
@@ -1531,8 +1635,11 @@ BR2_PACKAGE_FDK_AAC_ARCH_SUPPORTS=y
 #
 # libmodplug needs a toolchain w/ C++
 #
-# BR2_PACKAGE_LIBMPD is not set
 # BR2_PACKAGE_LIBMPDCLIENT is not set
+
+#
+# libopenmpt needs a toolchain w/ threads, C++, gcc >= 7
+#
 # BR2_PACKAGE_LIBREPLAYGAIN is not set
 # BR2_PACKAGE_LIBSAMPLERATE is not set
 
@@ -1556,7 +1663,7 @@ BR2_PACKAGE_FDK_AAC_ARCH_SUPPORTS=y
 BR2_PACKAGE_OPENAL_ARCH_SUPPORTS=y
 
 #
-# openal needs a toolchain w/ NPTL, C++, gcc >= 4.9
+# openal needs a toolchain w/ NPTL, C++, gcc >= 7
 #
 
 #
@@ -1565,6 +1672,7 @@ BR2_PACKAGE_OPENAL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_OPUS is not set
 # BR2_PACKAGE_OPUSFILE is not set
 # BR2_PACKAGE_PORTAUDIO is not set
+# BR2_PACKAGE_RNNOISE is not set
 # BR2_PACKAGE_SBC is not set
 # BR2_PACKAGE_SPANDSP is not set
 # BR2_PACKAGE_SPEEX is not set
@@ -1580,7 +1688,7 @@ BR2_PACKAGE_OPENAL_ARCH_SUPPORTS=y
 BR2_PACKAGE_WEBRTC_AUDIO_PROCESSING_ARCH_SUPPORTS=y
 
 #
-# webrtc-audio-processing needs a toolchain w/ C++, NPTL, gcc >= 4.8
+# webrtc-audio-processing needs a toolchain w/ C++, NPTL, dynamic library, gcc >= 8
 #
 
 #
@@ -1588,6 +1696,7 @@ BR2_PACKAGE_WEBRTC_AUDIO_PROCESSING_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_LIBARCHIVE is not set
 # BR2_PACKAGE_LIBDEFLATE is not set
+# BR2_PACKAGE_LIBJCAT is not set
 # BR2_PACKAGE_LIBMSPACK is not set
 
 #
@@ -1617,11 +1726,10 @@ BR2_PACKAGE_PROVIDES_HOST_ZLIB="host-libzlib"
 # Crypto
 #
 # BR2_PACKAGE_BEARSSL is not set
-# BR2_PACKAGE_BEECRYPT is not set
 BR2_PACKAGE_BOTAN_ARCH_SUPPORTS=y
 
 #
-# botan needs a toolchain w/ C++, threads, gcc >= 4.8
+# botan needs a toolchain w/ threads, C++, gcc >= 11
 #
 # BR2_PACKAGE_CA_CERTIFICATES is not set
 
@@ -1647,10 +1755,6 @@ BR2_PACKAGE_LIBGPG_ERROR_SYSCFG="aarch64-unknown-linux-gnu"
 # BR2_PACKAGE_LIBMD is not set
 # BR2_PACKAGE_LIBMHASH is not set
 # BR2_PACKAGE_LIBNSS is not set
-
-#
-# libolm needs a toolchain w/ C++, gcc >= 4.8
-#
 # BR2_PACKAGE_LIBP11 is not set
 # BR2_PACKAGE_LIBSCRYPT is not set
 # BR2_PACKAGE_LIBSECRET is not set
@@ -1666,6 +1770,8 @@ BR2_PACKAGE_LIBSPDM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBXCRYPT is not set
 # BR2_PACKAGE_MBEDTLS is not set
 # BR2_PACKAGE_NETTLE is not set
+# BR2_PACKAGE_OATH_TOOLKIT is not set
+BR2_PACKAGE_LIBRESSL_ARCH_SUPPORTS=y
 BR2_PACKAGE_OPENSSL=y
 BR2_PACKAGE_LIBOPENSSL=y
 BR2_PACKAGE_LIBOPENSSL_TARGET_ARCH="linux-aarch64"
@@ -1692,13 +1798,29 @@ BR2_PACKAGE_LIBOPENSSL_ENABLE_CAST=y
 BR2_PACKAGE_LIBOPENSSL_UNSECURE=y
 BR2_PACKAGE_LIBOPENSSL_DYNAMIC_ENGINE=y
 BR2_PACKAGE_LIBOPENSSL_ENABLE_COMP=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_ARGON2=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_CACHED_FETCH=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_CMP=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_THREAD_POOL=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_ECX=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_LOADER_ENGINE=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_PADLOCK_ENGINE=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_MODULE=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_QUIC=y
+BR2_PACKAGE_LIBOPENSSL_SECURE_MEMORY=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_SIV=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_SM2_PRECOMP_TABLE=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_SSL_TRACE=y
 # BR2_PACKAGE_LIBRESSL is not set
 BR2_PACKAGE_HAS_OPENSSL=y
 BR2_PACKAGE_PROVIDES_OPENSSL="libopenssl"
 BR2_PACKAGE_PROVIDES_HOST_OPENSSL="host-libopenssl"
+# BR2_PACKAGE_PARSEC is not set
+# BR2_PACKAGE_PARSEC_TOOL is not set
 # BR2_PACKAGE_PKCS11_HELPER is not set
 # BR2_PACKAGE_RHASH is not set
 # BR2_PACKAGE_TINYDTLS is not set
+# BR2_PACKAGE_TPM2_OPENSSL is not set
 # BR2_PACKAGE_TPM2_PKCS11 is not set
 # BR2_PACKAGE_TPM2_TSS is not set
 # BR2_PACKAGE_TROUSERS is not set
@@ -1739,31 +1861,30 @@ BR2_PACKAGE_WOLFSSL_ASM_SUPPORTS=y
 #
 
 #
-# libpqxx needs toolchain w/ C++, gcc >= 7, threads
+# libpqxx needs toolchain w/ C++, gcc >= 9, threads
 #
-BR2_PACKAGE_MONGODB_ARCH_SUPPORTS=y
+# BR2_PACKAGE_LMDB is not set
 
 #
-# mongodb needs a glibc toolchain w/ wchar, threads, C++, gcc >= 7
-#
-
-#
-# mysql needs a toolchain w/ C++, threads
+# mariadb needs a toolchain w/ dynamic library, C++, threads, wchar
 #
 BR2_PACKAGE_POSTGRESQL=y
 # BR2_PACKAGE_POSTGRESQL_FULL is not set
 
 #
-# osm2pgsql needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# osm2pgsql needs a toolchain w/ C++, wchar, threads, gcc >= 8
 #
 
 #
-# postgis needs a toolchain w/ C++, threads, wchar, gcc >= 4.9, not binutils bug 27597
+# postgis needs a toolchain w/ C++, NPTL, wchar, gcc >= 7
 #
-# BR2_PACKAGE_REDIS is not set
 
 #
-# redis-plus-plus needs a toolchain w/ C++
+# redis needs a toolchain w/ gcc>=4.9, dynamic library, nptl, C++
+#
+
+#
+# redis-plus-plus needs a toolchain w/ C++, threads
 #
 BR2_PACKAGE_ROCKSDB_ARCH_SUPPORTS=y
 
@@ -1772,13 +1893,16 @@ BR2_PACKAGE_ROCKSDB_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_SQLCIPHER is not set
 # BR2_PACKAGE_SQLITE is not set
+
+#
+# sqlitecpp needs a toolchain w/ C++11, gcc >= 4.9
+#
 # BR2_PACKAGE_TIMESCALEDB is not set
 # BR2_PACKAGE_UNIXODBC is not set
 
 #
 # Filesystem
 #
-# BR2_PACKAGE_GAMIN is not set
 # BR2_PACKAGE_LIBCONFIG is not set
 # BR2_PACKAGE_LIBCONFUSE is not set
 # BR2_PACKAGE_LIBFUSE is not set
@@ -1802,11 +1926,11 @@ BR2_PACKAGE_ROCKSDB_ARCH_SUPPORTS=y
 # BR2_PACKAGE_AT_SPI2_CORE is not set
 
 #
-# atkmm needs a toolchain w/ C++, wchar, threads, gcc >= 7
+# atkmm needs a toolchain w/ C++, wchar, threads, gcc >= 7, dynamic library
 #
 
 #
-# atkmm (2.28.x) needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# atkmm (2.28.x) needs a toolchain w/ C++, wchar, threads, gcc >= 4.9, dynamic library
 #
 BR2_PACKAGE_BAYER2RGB_NEON_ARCH_SUPPORTS=y
 
@@ -1845,7 +1969,7 @@ BR2_PACKAGE_FLUTTER_ENGINE_ARCH_SUPPORTS=y
 #
 
 #
-# flutter-engine needs a glibc toolchain w/ wchar, C++, gcc >= 5, dynamic library, host gcc >= 5, NPTL
+# flutter-engine needs a glibc toolchain w/ wchar, C++, gcc >= 5, dynamic library, host gcc >= 5
 #
 # BR2_PACKAGE_FONTCONFIG is not set
 # BR2_PACKAGE_FREETYPE is not set
@@ -1856,13 +1980,14 @@ BR2_PACKAGE_FLUTTER_ENGINE_ARCH_SUPPORTS=y
 #
 # granite needs libgtk3 and a toolchain w/ wchar, threads, gcc >= 4.9
 #
+# BR2_PACKAGE_GRAPHENE is not set
 
 #
 # graphite2 needs a toolchain w/ C++
 #
 
 #
-# gtkmm3 needs libgtk3 and a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# gtkmm3 needs libgtk3 and a toolchain w/ C++, wchar, threads, gcc >= 4.9, dynamic library
 #
 
 #
@@ -1893,6 +2018,7 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 #
 # BR2_PACKAGE_LEPTONICA is not set
 # BR2_PACKAGE_LIBART is not set
+# BR2_PACKAGE_LIBAVIF is not set
 
 #
 # libdecor needs a toolchain w/ wchar, threads, C++, gcc >= 4.9
@@ -1906,7 +2032,11 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 # BR2_PACKAGE_LIBEXIF is not set
 
 #
-# libfm needs X.org and a toolchain w/ wchar, threads, C++, gcc >= 4.9
+# libfm a toolchain w/ wchar, threads, C++, gcc >= 4.9
+#
+
+#
+# libfm needs X.org with an OpenGL backend
 #
 # BR2_PACKAGE_LIBFM_EXTRA is not set
 
@@ -1919,7 +2049,7 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 #
 
 #
-# libgeotiff needs a toolchain w/ C++, gcc >= 4.7, threads, wchar
+# libgeotiff needs a toolchain w/ C++, gcc >= 4.7, NPTL, wchar
 #
 
 #
@@ -1940,7 +2070,15 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 #
 
 #
-# libgtk3 needs an OpenGL or an OpenGL-EGL/wayland backend
+# libgtk3 needs an OpenGL or an OpenGL-EGL backend
+#
+
+#
+# libgtk4 needs a toolchain w/ wchar, threads, C++, gcc >= 4.9
+#
+
+#
+# libgtk4 needs an OpenGL(ES) EGL backend
 #
 
 #
@@ -1960,26 +2098,22 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 #
 # BR2_PACKAGE_LIBSVG is not set
 # BR2_PACKAGE_LIBSVG_CAIRO is not set
-# BR2_PACKAGE_LIBSVGTINY is not set
 # BR2_PACKAGE_LIBVA is not set
 
 #
 # libvips needs a toolchain w/ wchar, threads, C++
+#
+BR2_PACKAGE_LIBVPL_ARCH_SUPPORTS=y
+
+#
+# libvpl needs a toolchain w/ dynamic library, gcc >= 7, C++, threads
 #
 
 #
 # libwpe needs a toolchain w/ C++, dynamic library and an OpenEGL-capable backend
 #
 # BR2_PACKAGE_MENU_CACHE is not set
-BR2_PACKAGE_ONEVPL_ARCH_SUPPORTS=y
-
-#
-# onevpl needs a toolchain w/ dynamic library, gcc >= 7, C++, threads
-#
-
-#
-# onevpl-intel-gpu needs a toolchain w/ dynamic library, gcc >= 7, C++, NPTL
-#
+# BR2_PACKAGE_OPENCL_HEADERS is not set
 
 #
 # opencv3 needs a toolchain w/ C++, NPTL, wchar, dynamic library
@@ -2012,12 +2146,12 @@ BR2_PACKAGE_ONEVPL_ARCH_SUPPORTS=y
 BR2_PACKAGE_WEBKITGTK_ARCH_SUPPORTS=y
 
 #
-# webkitgtk needs libgtk3 and a toolchain w/ C++, wchar, threads, dynamic library, gcc >= 9, host gcc >= 4.9
+# webkitgtk needs libgtk3 or libgtk4 and a toolchain w/ C++, wchar, NPTL, dynamic library, gcc >= 11, host gcc >= 4.9
 #
 # BR2_PACKAGE_WEBP is not set
 
 #
-# wlroots needs udev, EGL w/ Wayland backend and OpenGL ES support
+# wlroots needs udev, EGL, OpenGL ES and GBM support
 #
 
 #
@@ -2025,12 +2159,12 @@ BR2_PACKAGE_WEBKITGTK_ARCH_SUPPORTS=y
 #
 
 #
-# wpebackend-fdo needs a toolchain w/ C++, wchar, threads, dynamic library and an OpenEGL-capable Wayland backend
+# wpebackend-fdo needs a toolchain w/ C++, wchar, threads, dynamic library and EGL support
 #
 BR2_PACKAGE_WPEWEBKIT_ARCH_SUPPORTS=y
 
 #
-# wpewebkit needs a toolchain w/ C++, wchar, threads, dynamic library, gcc >= 9, host gcc >= 4.9
+# wpewebkit needs a toolchain w/ C++, wchar, NPTL, dynamic library, gcc >= 11, host gcc >= 4.9
 #
 
 #
@@ -2042,7 +2176,7 @@ BR2_PACKAGE_WPEWEBKIT_ARCH_SUPPORTS=y
 #
 
 #
-# zxing-cpp needs a toolchain w/ C++, wchar, dynamic library
+# zxing-cpp needs a toolchain w/ C++, wchar, dynamic library, threads
 #
 
 #
@@ -2051,13 +2185,15 @@ BR2_PACKAGE_WPEWEBKIT_ARCH_SUPPORTS=y
 # BR2_PACKAGE_ACSCCID is not set
 # BR2_PACKAGE_C_PERIPHERY is not set
 # BR2_PACKAGE_CCID is not set
+BR2_PACKAGE_CPUINFO_ARCH_SUPPORTS=y
+# BR2_PACKAGE_CPUINFO is not set
 # BR2_PACKAGE_DTC is not set
 BR2_PACKAGE_GNU_EFI_ARCH_SUPPORTS=y
 # BR2_PACKAGE_GNU_EFI is not set
 # BR2_PACKAGE_HACKRF is not set
 
 #
-# hidapi needs udev /dev management and a toolchain w/ NPTL, threads, gcc >= 4.9
+# hidapi needs udev /dev management and a toolchain w/ NPTL, gcc >= 4.9
 #
 # BR2_PACKAGE_JITTERENTROPY_LIBRARY is not set
 
@@ -2087,11 +2223,11 @@ BR2_PACKAGE_GNU_EFI_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBFTDI1 is not set
 # BR2_PACKAGE_LIBGPHOTO2 is not set
 # BR2_PACKAGE_LIBGPIOD is not set
+# BR2_PACKAGE_LIBGPIOD2 is not set
 
 #
 # libgudev needs udev /dev handling and a toolchain w/ wchar, threads
 #
-# BR2_PACKAGE_LIBHID is not set
 # BR2_PACKAGE_LIBIIO is not set
 
 #
@@ -2145,14 +2281,19 @@ BR2_PACKAGE_OPENCSD_ARCH_SUPPORTS=y
 # BR2_PACKAGE_OPENSC is not set
 # BR2_PACKAGE_OWFS is not set
 # BR2_PACKAGE_PCSC_LITE is not set
+# BR2_PACKAGE_PICO_SDK is not set
 
 #
 # rpi-rgb-led-matrix needs a toolchain w/ C++, threads, dynamic library
 #
+
+#
+# SoapySDR needs a toolchain w/ C++, threads, dynamic library
+#
 # BR2_PACKAGE_TSLIB is not set
 
 #
-# uhd needs a toolchain w/ C++, NPTL, wchar, dynamic library, gcc >= 5
+# uhd needs a toolchain w/ C++, NPTL, wchar, dynamic library, gcc >= 7
 #
 
 #
@@ -2162,7 +2303,6 @@ BR2_PACKAGE_OPENCSD_ARCH_SUPPORTS=y
 #
 # Javascript
 #
-# BR2_PACKAGE_ANGULARJS is not set
 # BR2_PACKAGE_BOOTSTRAP is not set
 # BR2_PACKAGE_CHARTJS is not set
 # BR2_PACKAGE_DATATABLES is not set
@@ -2175,7 +2315,6 @@ BR2_PACKAGE_OPENCSD_ARCH_SUPPORTS=y
 # BR2_PACKAGE_JSON_JAVASCRIPT is not set
 # BR2_PACKAGE_JSZIP is not set
 # BR2_PACKAGE_OPENLAYERS is not set
-# BR2_PACKAGE_POPPERJS is not set
 # BR2_PACKAGE_VIS_NETWORK is not set
 # BR2_PACKAGE_VUEJS is not set
 
@@ -2201,7 +2340,6 @@ BR2_PACKAGE_OPENCSD_ARCH_SUPPORTS=y
 #
 # jsoncpp needs a toolchain w/ C++, gcc >= 4.7
 #
-# BR2_PACKAGE_LIBBSON is not set
 # BR2_PACKAGE_LIBFASTJSON is not set
 
 #
@@ -2210,6 +2348,7 @@ BR2_PACKAGE_OPENCSD_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBROXML is not set
 # BR2_PACKAGE_LIBUCL is not set
 # BR2_PACKAGE_LIBXML2 is not set
+# BR2_PACKAGE_LIBXMLB is not set
 
 #
 # libxml++ needs a toolchain w/ C++, wchar, threads, gcc >= 7
@@ -2261,7 +2400,7 @@ BR2_PACKAGE_OPENCSD_ARCH_SUPPORTS=y
 #
 
 #
-# glog needs a toolchain w/ C++
+# glog needs a toolchain w/ C++, threads, gcc >= 6
 #
 
 #
@@ -2279,7 +2418,7 @@ BR2_PACKAGE_OPENCSD_ARCH_SUPPORTS=y
 #
 
 #
-# log4cxx needs a toolchain w/ C++, threads, dynamic library
+# log4cxx needs a toolchain w/ C++, threads, dynamic library, wchar
 #
 
 #
@@ -2326,7 +2465,7 @@ BR2_PACKAGE_LIBCAMERA_ARCH_SUPPORTS=y
 #
 
 #
-# libcamera-apps needs a toolchain w/ C++, threads, wchar, dynamic library, gcc >= 8
+# libcamera-apps needs a toolchain w/ C++, threads, wchar, dynamic library, gcc >= 8, headers >= 5.5
 #
 
 #
@@ -2348,7 +2487,7 @@ BR2_PACKAGE_LIBCAMERA_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBHDHOMERUN is not set
 
 #
-# libheif needs a toolchain w/ C++, gcc >= 4.8
+# libheif needs a toolchain w/ C++, threads, gcc >= 4.8
 #
 
 #
@@ -2375,10 +2514,6 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 # live555 needs a toolchain w/ C++
 #
-
-#
-# mediastreamer needs a toolchain w/ threads, C++, dynamic library, gcc >= 5
-#
 # BR2_PACKAGE_X264 is not set
 
 #
@@ -2404,13 +2539,12 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 # batman-adv needs a Linux kernel to be built
 #
+# BR2_PACKAGE_C_ARES is not set
+# BR2_PACKAGE_CNI_PLUGINS is not set
 
 #
-# belle-sip needs a toolchain w/ threads, C++, dynamic library, wchar
+# cpp-httplib needs a toolchain w/ C++, wchar, threads
 #
-# BR2_PACKAGE_C_ARES is not set
-# BR2_PACKAGE_CGIC is not set
-# BR2_PACKAGE_CNI_PLUGINS is not set
 
 #
 # cppzmq needs a toolchain w/ C++, threads
@@ -2427,19 +2561,24 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 # BR2_PACKAGE_DAQ3 is not set
 # BR2_PACKAGE_DAVICI is not set
 # BR2_PACKAGE_DHT is not set
+BR2_PACKAGE_DPDK_ARCH_SUPPORTS=y
+# BR2_PACKAGE_DPDK is not set
 # BR2_PACKAGE_ENET is not set
 
 #
 # filemq needs a toolchain w/ C++, threads
 #
-# BR2_PACKAGE_FLICKCURL is not set
+
+#
+# fmlib needs a Linux kernel to be built
+#
 # BR2_PACKAGE_FREERADIUS_CLIENT is not set
 # BR2_PACKAGE_GENSIO is not set
 # BR2_PACKAGE_GEOIP is not set
 # BR2_PACKAGE_GLIB_NETWORKING is not set
 
 #
-# grpc needs a toolchain w/ C++, threads, dynamic library, gcc >= 5
+# grpc needs a toolchain w/ C++, threads, dynamic library, gcc >= 8
 #
 # BR2_PACKAGE_GSSDP is not set
 # BR2_PACKAGE_GUPNP is not set
@@ -2473,7 +2612,7 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBHTTPPARSER is not set
 
 #
-# libhttpserver needs a toolchain w/ C++, threads, gcc >= 5
+# libhttpserver needs a toolchain w/ C++, threads, gcc >= 7
 #
 # BR2_PACKAGE_LIBIDN is not set
 # BR2_PACKAGE_LIBIDN2 is not set
@@ -2513,7 +2652,6 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 # libnpupnp needs a toolchain w/ C++, threads, gcc >= 4.9
 #
-# BR2_PACKAGE_LIBOAUTH is not set
 # BR2_PACKAGE_LIBOPING is not set
 # BR2_PACKAGE_LIBOSIP2 is not set
 # BR2_PACKAGE_LIBPAGEKITE is not set
@@ -2557,9 +2695,10 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_LIBUWSC is not set
 # BR2_PACKAGE_LIBVNCSERVER is not set
-# BR2_PACKAGE_LIBWEBSOCK is not set
 # BR2_PACKAGE_LIBWEBSOCKETS is not set
 # BR2_PACKAGE_LIBYANG is not set
+BR2_PACKAGE_LIBZENOH_C_ARCH_SUPPORTS=y
+# BR2_PACKAGE_LIBZENOH_C is not set
 # BR2_PACKAGE_LIBZENOH_PICO is not set
 # BR2_PACKAGE_LKSCTP_TOOLS is not set
 # BR2_PACKAGE_MBUFFER is not set
@@ -2598,10 +2737,6 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 # openzwave needs a toolchain w/ C++, dynamic library, NPTL, wchar
 #
-
-#
-# ortp needs a toolchain w/ C++, threads
-#
 # BR2_PACKAGE_PAHO_MQTT_C is not set
 
 #
@@ -2609,7 +2744,7 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 
 #
-# pistache needs a toolchain w/ C++, gcc >= 7, threads, wchar, not binutils bug 27597
+# pistache needs a toolchain w/ C++, gcc >= 7, NPTL, wchar
 #
 # BR2_PACKAGE_QDECODER is not set
 
@@ -2683,15 +2818,8 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 # atf needs a toolchain w/ C++
 #
 # BR2_PACKAGE_AVRO_C is not set
-
-#
-# bctoolbox needs a toolchain w/ C++, threads
-#
+# BR2_PACKAGE_BASU is not set
 # BR2_PACKAGE_BDWGC is not set
-
-#
-# belr needs a toolchain w/ threads, C++
-#
 
 #
 # boost needs a toolchain w/ C++, threads, wchar
@@ -2731,6 +2859,10 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 # dawgdic needs a toolchain w/ C++, gcc >= 4.6
 #
 # BR2_PACKAGE_DING_LIBS is not set
+
+#
+# dlib needs a toolchain w/ C++, threads, wchar
+#
 # BR2_PACKAGE_DOTCONF is not set
 
 #
@@ -2742,6 +2874,11 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_ELFUTILS is not set
 # BR2_PACKAGE_ELL is not set
+
+#
+# farmhash needs a toolchain w/ C++11
+#
+# BR2_PACKAGE_FFT2D is not set
 # BR2_PACKAGE_FFTW is not set
 
 #
@@ -2752,11 +2889,16 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 # flatbuffers needs a toolchain w/ C++, gcc >= 4.7
 #
 # BR2_PACKAGE_FLATCC is not set
+# BR2_PACKAGE_FP16 is not set
 # BR2_PACKAGE_FXDIV is not set
 # BR2_PACKAGE_GCONF is not set
 
 #
-# gdal needs a toolchain w/ C++, dynamic library, gcc >= 4.7, not binutils bug 27597, threads, wchar
+# gdal needs a toolchain w/ C++, dynamic library, gcc >= 4.7, NPTL, wchar
+#
+
+#
+# gemmlowp needs a toolchain w/ C++11
 #
 
 #
@@ -2787,7 +2929,7 @@ BR2_PACKAGE_GOBJECT_INTROSPECTION_ARCH_SUPPORTS=y
 # BR2_PACKAGE_GSL is not set
 
 #
-# gtest needs a toolchain w/ C++, wchar, threads, gcc >= 5
+# gtest needs a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 # BR2_PACKAGE_GUMBO_PARSER is not set
 
@@ -2804,9 +2946,8 @@ BR2_PACKAGE_LAPACK_ARCH_SUPPORTS=y
 BR2_PACKAGE_LIBABSEIL_CPP_ARCH_SUPPORTS=y
 
 #
-# libabseil-cpp needs a toolchain w/ gcc >= 4.9, C++, threads, dynamic library
+# libabseil-cpp needs a toolchain w/ gcc >= 8, C++, threads, dynamic library
 #
-# BR2_PACKAGE_LIBARGTABLE2 is not set
 BR2_PACKAGE_LIBATOMIC_OPS_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBATOMIC_OPS is not set
 # BR2_PACKAGE_LIBAVL is not set
@@ -2819,7 +2960,7 @@ BR2_PACKAGE_LIBBSD_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBCAP_NG is not set
 
 #
-# libcgroup needs a toolchain w/ C++
+# libcgroup needs a toolchain w/ C++, threads
 #
 # BR2_PACKAGE_LIBCLC is not set
 # BR2_PACKAGE_LIBCORRECT is not set
@@ -2829,6 +2970,7 @@ BR2_PACKAGE_LIBBSD_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_LIBCSV is not set
 # BR2_PACKAGE_LIBDAEMON is not set
+# BR2_PACKAGE_LIBDEX is not set
 # BR2_PACKAGE_LIBDILL is not set
 BR2_PACKAGE_LIBEASTL_ARCH_SUPPORTS=y
 
@@ -2851,7 +2993,7 @@ BR2_PACKAGE_LIBEASTL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBGEE is not set
 
 #
-# libgeos needs a toolchain w/ C++, wchar, gcc >= 4.9, threads not binutils bug 27597
+# libgeos needs a toolchain w/ C++, wchar, gcc >= 7, threads
 #
 # BR2_PACKAGE_LIBGLIB2 is not set
 # BR2_PACKAGE_LIBGLOB is not set
@@ -2877,7 +3019,7 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # BR2_PACKAGE_LIBNSPR is not set
 
 #
-# libosmium needs a toolchain w/ C++, wchar, threads, gcc >= 4.7
+# libosmium needs a toolchain w/ C++, wchar, threads, gcc >= 5
 #
 
 #
@@ -2927,9 +3069,15 @@ BR2_PACKAGE_LIBURCU_ARCH_SUPPORTS=y
 # liburcu needs a toolchain w/ threads, C++
 #
 # BR2_PACKAGE_LIBURING is not set
+# BR2_PACKAGE_LIBUTEMPTER is not set
 # BR2_PACKAGE_LIBUV is not set
 # BR2_PACKAGE_LINUX_PAM is not set
 # BR2_PACKAGE_LIQUID_DSP is not set
+BR2_PACKAGE_LLAMA_CPP_ARCH_SUPPORTS=y
+
+#
+# llama-cpp needs a toolchain w/ C++, wchar, threads, and gcc >= 9
+#
 BR2_PACKAGE_LLVM_ARCH_SUPPORTS=y
 BR2_PACKAGE_LLVM_TARGET_ARCH="AArch64"
 
@@ -2949,6 +3097,7 @@ BR2_PACKAGE_LLVM_TARGET_ARCH="AArch64"
 #
 # msgpack needs a toolchain w/ C++
 #
+# BR2_PACKAGE_MSGPACK_C is not set
 # BR2_PACKAGE_NEON_2_SSE is not set
 BR2_PACKAGE_OPENBLAS_DEFAULT_TARGET="ARMV8"
 BR2_PACKAGE_OPENBLAS_ARCH_SUPPORTS=y
@@ -2958,22 +3107,24 @@ BR2_PACKAGE_OPENBLAS_ARCH_SUPPORTS=y
 BR2_PACKAGE_POCO_ARCH_SUPPORTS=y
 
 #
-# poco needs a toolchain w/ wchar, NPTL, C++, dynamic library, gcc >= 5 w/ C++14
+# poco needs a toolchain w/ wchar, NPTL, C++, dynamic library, gcc >= 8
 #
 BR2_PACKAGE_HOST_PROTOBUF_ARCH_SUPPORTS=y
 BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 
 #
-# protobuf needs a toolchain w/ C++, threads, dynamic library, gcc >= 4.8
+# protobuf needs a toolchain w/ C++, threads, dynamic library, gcc >= 8
 #
 
 #
-# protobuf-c needs a toolchain w/ C++, threads
+# protobuf-c needs a toolchain w/ C++, threads, host gcc >= 7
 #
 
 #
 # protozero needs a toolchain w/ C++, gcc >= 4.7
 #
+# BR2_PACKAGE_PSIMD is not set
+# BR2_PACKAGE_PTHREADPOOL is not set
 
 #
 # qhull needs a toolchain w/ C++, gcc >= 4.4
@@ -2982,7 +3133,12 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 # BR2_PACKAGE_REPROC is not set
 
 #
-# riemann-c-client needs a toolchain w/ C++, threads
+# riemann-c-client needs a toolchain w/ C++, threads, host gcc >= 7
+#
+BR2_PACKAGE_RUY_ARCH_SUPPORTS=y
+
+#
+# ruy needs a toolchain w/ C++14, threads
 #
 
 #
@@ -2994,11 +3150,17 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 #
 # tbb needs a glibc or musl toolchain w/ dynamic library, threads, C++
 #
+BR2_PACKAGE_TENSORFLOW_LITE_ARCH_SUPPORTS=y
+
+#
+# tensorflow-lite needs a toolchain w/ gcc >= 8, C++, threads
+#
 # BR2_PACKAGE_TINYCBOR is not set
 
 #
 # tl-expected needs a toolchain w/ C++, gcc >= 4.8
 #
+# BR2_PACKAGE_TLLIST is not set
 
 #
 # uvw needs a toolchain w/ NPTL, dynamic library, C++, gcc >= 7
@@ -3010,6 +3172,10 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 
 #
 # xapian needs a toolchain w/ C++
+#
+
+#
+# xnnpack needs a toolchain w/ C++14, threads
 #
 
 #
@@ -3041,6 +3207,7 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 #
 # enchant needs a toolchain w/ C++, threads, wchar
 #
+# BR2_PACKAGE_FCFT is not set
 
 #
 # fmt needs a toolchain w/ C++, wchar
@@ -3052,6 +3219,7 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_INIH is not set
 # BR2_PACKAGE_LIBCLI is not set
+# BR2_PACKAGE_LIBECOLI is not set
 # BR2_PACKAGE_LIBEDIT is not set
 # BR2_PACKAGE_LIBENCA is not set
 # BR2_PACKAGE_LIBESTR is not set
@@ -3067,7 +3235,7 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 # BR2_PACKAGE_POPT is not set
 
 #
-# re2 needs a toolchain w/ C++, threads, gcc >= 4.8
+# re2 needs a toolchain w/ C++, threads, dynamic library, gcc >= 8
 #
 # BR2_PACKAGE_READLINE is not set
 # BR2_PACKAGE_SLANG is not set
@@ -3080,6 +3248,10 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 # termcolor needs a toolchain w/ C++, gcc >= 4.8
 #
 # BR2_PACKAGE_UTF8PROC is not set
+
+#
+# taglib needs a toolchain w/ C++
+#
 
 #
 # Mail
@@ -3100,7 +3272,7 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 BR2_PACKAGE_BITCOIN_ARCH_SUPPORTS=y
 
 #
-# bitcoin needs a toolchain w/ C++, threads, wchar
+# bitcoin needs a toolchain w/ C++, threads, wchar, gcc >= 11
 #
 
 #
@@ -3135,7 +3307,7 @@ BR2_PACKAGE_BITCOIN_ARCH_SUPPORTS=y
 # BR2_PACKAGE_NETDATA is not set
 
 #
-# proj needs a toolchain w/ C++, gcc >= 4.7, threads, wchar
+# proj needs a toolchain w/ C++, gcc >= 4.7, NPTL, wchar
 #
 BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 # BR2_PACKAGE_QEMU is not set
@@ -3145,6 +3317,7 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 #
 # BR2_PACKAGE_RTL_433 is not set
 # BR2_PACKAGE_SHARED_MIME_INFO is not set
+# BR2_PACKAGE_SNOOZE is not set
 
 #
 # sunwait needs a toolchain w/ C++
@@ -3164,6 +3337,7 @@ BR2_PACKAGE_Z3_ARCH_SUPPORTS=y
 #
 # Networking applications
 #
+# BR2_PACKAGE_AARDVARK_DNS is not set
 
 #
 # aircrack-ng needs a toolchain w/ dynamic library, threads, C++
@@ -3204,12 +3378,14 @@ BR2_PACKAGE_Z3_ARCH_SUPPORTS=y
 # BR2_PACKAGE_CAN_UTILS is not set
 
 #
-# cannelloni needs a toolchain w/ C++, threads, dynamic library, gcc >= 4.8
+# cannelloni needs a toolchain w/ C++, threads, dynamic library, gcc >= 8
 #
 # BR2_PACKAGE_CASYNC is not set
+# BR2_PACKAGE_CASYNC_NANO is not set
 # BR2_PACKAGE_CFM is not set
 # BR2_PACKAGE_CHRONY is not set
 # BR2_PACKAGE_CIVETWEB is not set
+# BR2_PACKAGE_CLOUDFLARED is not set
 # BR2_PACKAGE_CONNMAN is not set
 
 #
@@ -3250,6 +3426,14 @@ BR2_PACKAGE_Z3_ARCH_SUPPORTS=y
 # BR2_PACKAGE_FCGIWRAP is not set
 # BR2_PACKAGE_FIREWALLD is not set
 # BR2_PACKAGE_FLANNEL is not set
+
+#
+# fmc needs a toolchain w/ C++
+#
+
+#
+# fmc needs a Linux kernel to be built
+#
 # BR2_PACKAGE_FPING is not set
 # BR2_PACKAGE_FREERADIUS_SERVER is not set
 
@@ -3257,6 +3441,10 @@ BR2_PACKAGE_Z3_ARCH_SUPPORTS=y
 # freeswitch needs a toolchain w/ C++, dynamic library, threads, wchar
 #
 # BR2_PACKAGE_FRR is not set
+
+#
+# protobuf support for frr needs a toolchain w/ protobuf, C++, host gcc >= 7
+#
 
 #
 # gerbera needs a toolchain w/ C++, dynamic library, threads, wchar, gcc >= 8
@@ -3267,6 +3455,7 @@ BR2_PACKAGE_Z3_ARCH_SUPPORTS=y
 # gloox needs a toolchain w/ C++
 #
 # BR2_PACKAGE_GLORYTUN is not set
+# BR2_PACKAGE_GROUT is not set
 
 #
 # gupnp-tools needs libgtk3
@@ -3277,7 +3466,6 @@ BR2_PACKAGE_Z3_ARCH_SUPPORTS=y
 #
 BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HAPROXY is not set
-# BR2_PACKAGE_HIAWATHA is not set
 # BR2_PACKAGE_HOSTAPD is not set
 # BR2_PACKAGE_HTPDATE is not set
 # BR2_PACKAGE_HTTPING is not set
@@ -3285,6 +3473,7 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 #
 # i2pd needs a toolchain w/ C++, NPTL, wchar
 #
+# BR2_PACKAGE_IANA_ASSIGNMENTS is not set
 
 #
 # ibrdtn-tools needs a toolchain w/ C++, threads
@@ -3321,7 +3510,7 @@ BR2_PACKAGE_IFUPDOWN_SCRIPTS=y
 # BR2_PACKAGE_KEEPALIVED is not set
 
 #
-# kismet needs a toolchain w/ threads, C++, gcc >= 5
+# kismet needs a toolchain w/ threads, C++, gcc >= 5, host gcc >= 7
 #
 # BR2_PACKAGE_KNOCK is not set
 # BR2_PACKAGE_KSMBD_TOOLS is not set
@@ -3337,13 +3526,10 @@ BR2_PACKAGE_IFUPDOWN_SCRIPTS=y
 # linknx needs a toolchain w/ C++
 #
 # BR2_PACKAGE_LINKS is not set
-
-#
-# linphone needs a toolchain w/ threads, C++, dynamic library, wchar, gcc >= 5
-#
 # BR2_PACKAGE_LINUX_ZIGBEE is not set
 # BR2_PACKAGE_LINUXPTP is not set
 # BR2_PACKAGE_LLDPD is not set
+# BR2_PACKAGE_LPAC is not set
 # BR2_PACKAGE_LRZSZ is not set
 # BR2_PACKAGE_LYNX is not set
 # BR2_PACKAGE_MACCHANGER is not set
@@ -3354,14 +3540,9 @@ BR2_PACKAGE_IFUPDOWN_SCRIPTS=y
 # BR2_PACKAGE_MINISSDPD is not set
 # BR2_PACKAGE_MJPG_STREAMER is not set
 # BR2_PACKAGE_MODEM_MANAGER is not set
-BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 
 #
-# mongrel2 needs a uClibc or glibc toolchain w/ C++, threads, dynamic library
-#
-
-#
-# mosh needs a toolchain w/ C++, threads, dynamic library, wchar, gcc >= 4.8
+# mosh needs a toolchain w/ C++, threads, dynamic library, wchar, gcc >= 8
 #
 # BR2_PACKAGE_MOSQUITTO is not set
 # BR2_PACKAGE_MROUTED is not set
@@ -3372,13 +3553,17 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 # BR2_PACKAGE_NCFTP is not set
 # BR2_PACKAGE_NDISC6 is not set
 # BR2_PACKAGE_NETATALK is not set
+# BR2_PACKAGE_NETAVARK is not set
 # BR2_PACKAGE_NETCALC is not set
-# BR2_PACKAGE_NETPLUG is not set
-# BR2_PACKAGE_NETSNMP is not set
-# BR2_PACKAGE_NETSTAT_NAT is not set
 
 #
-# NetworkManager needs udev /dev management and a glibc toolchain w/ headers >= 4.6, dynamic library, wchar, threads, gcc >= 4.9
+# nethogs needs a toolchain w/ C++
+#
+# BR2_PACKAGE_NETPLUG is not set
+# BR2_PACKAGE_NETSNMP is not set
+
+#
+# NetworkManager needs udev /dev management and a glibc or musl toolchain w/ headers >= 5.4, dynamic library, wchar, threads, gcc >= 4.9
 #
 # BR2_PACKAGE_NFACCT is not set
 # BR2_PACKAGE_NFTABLES is not set
@@ -3403,6 +3588,7 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 # BR2_PACKAGE_OPEN_ISCSI is not set
 # BR2_PACKAGE_OPEN_LLDP is not set
 # BR2_PACKAGE_OPEN_PLC_UTILS is not set
+# BR2_PACKAGE_OPENCONNECT is not set
 # BR2_PACKAGE_OPENNTPD is not set
 # BR2_PACKAGE_OPENOBEX is not set
 # BR2_PACKAGE_OPENRESOLV is not set
@@ -3411,6 +3597,7 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 # BR2_PACKAGE_OPENVPN is not set
 # BR2_PACKAGE_P910ND is not set
 # BR2_PACKAGE_PARPROUTED is not set
+# BR2_PACKAGE_PASST is not set
 # BR2_PACKAGE_PHIDGETWEBSERVICE is not set
 # BR2_PACKAGE_PHYTOOL is not set
 # BR2_PACKAGE_PIMD is not set
@@ -3429,7 +3616,6 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 # BR2_PACKAGE_PTPD2 is not set
 # BR2_PACKAGE_PURE_FTPD is not set
 # BR2_PACKAGE_PUTTY is not set
-# BR2_PACKAGE_QUAGGA is not set
 # BR2_PACKAGE_RADVD is not set
 # BR2_PACKAGE_REAVER is not set
 # BR2_PACKAGE_REDIR is not set
@@ -3442,10 +3628,6 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 # rtorrent needs a toolchain w/ C++, threads, wchar, gcc >= 4.9
 #
 # BR2_PACKAGE_RTPTOOLS is not set
-
-#
-# rygel needs python3 and a glibc toolchain w/ wchar, threads, gcc >= 4.9, host gcc >= 8
-#
 # BR2_PACKAGE_S6_DNS is not set
 # BR2_PACKAGE_S6_NETWORKING is not set
 # BR2_PACKAGE_SAMBA4 is not set
@@ -3474,7 +3656,7 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 # BR2_PACKAGE_SPICE_PROTOCOL is not set
 
 #
-# squid needs a toolchain w/ C++, threads, gcc >= 4.8 not affected by bug 64735
+# squid needs a toolchain w/ C++, threads, gcc >= 8, host gcc >= 8
 #
 # BR2_PACKAGE_SSDP_RESPONDER is not set
 # BR2_PACKAGE_SSHGUARD is not set
@@ -3483,13 +3665,14 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 # BR2_PACKAGE_STRONGSWAN is not set
 # BR2_PACKAGE_STUNNEL is not set
 # BR2_PACKAGE_SURICATA is not set
+# BR2_PACKAGE_TAILSCALE is not set
 # BR2_PACKAGE_TCPDUMP is not set
 # BR2_PACKAGE_TCPING is not set
 # BR2_PACKAGE_TCPREPLAY is not set
-# BR2_PACKAGE_THTTPD is not set
 # BR2_PACKAGE_TINC is not set
 # BR2_PACKAGE_TINYPROXY is not set
 # BR2_PACKAGE_TINYSSH is not set
+# BR2_PACKAGE_TIPIDEE is not set
 # BR2_PACKAGE_TOR is not set
 # BR2_PACKAGE_TRACEROUTE is not set
 
@@ -3508,6 +3691,7 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 # BR2_PACKAGE_UREDIR is not set
 # BR2_PACKAGE_USHARE is not set
 # BR2_PACKAGE_USSP_PUSH is not set
+# BR2_PACKAGE_USTREAMER is not set
 # BR2_PACKAGE_VDE2 is not set
 
 #
@@ -3544,7 +3728,7 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 #
 
 #
-# znc needs a toolchain w/ C++, dynamic library, gcc >= 4.8, threads
+# znc needs a toolchain w/ C++, dynamic library, gcc >= 8, threads
 #
 
 #
@@ -3611,6 +3795,7 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 #
 # BR2_PACKAGE_CHECKPOLICY is not set
 # BR2_PACKAGE_IMA_EVM_UTILS is not set
+# BR2_PACKAGE_LYNIS is not set
 # BR2_PACKAGE_OPTEE_CLIENT is not set
 # BR2_PACKAGE_PAXTEST is not set
 # BR2_PACKAGE_POLICYCOREUTILS is not set
@@ -3653,11 +3838,17 @@ BR2_PACKAGE_GNUPG2_DEPENDS=y
 # BR2_PACKAGE_INOTIFY_TOOLS is not set
 # BR2_PACKAGE_LOCKFILE_PROGS is not set
 # BR2_PACKAGE_LOGROTATE is not set
-# BR2_PACKAGE_LOGSURFER is not set
+# BR2_PACKAGE_LOWDOWN is not set
+
+#
+# lowdown needs a toolchain w/ wchar and shared library support
+#
+# BR2_PACKAGE_MINISIGN is not set
 # BR2_PACKAGE_PDMENU is not set
 # BR2_PACKAGE_PINENTRY is not set
 # BR2_PACKAGE_QPRINT is not set
 # BR2_PACKAGE_RANGER is not set
+# BR2_PACKAGE_RLWRAP is not set
 # BR2_PACKAGE_RTTY is not set
 # BR2_PACKAGE_SCREEN is not set
 # BR2_PACKAGE_SEXPECT is not set
@@ -3665,15 +3856,21 @@ BR2_PACKAGE_GNUPG2_DEPENDS=y
 # BR2_PACKAGE_TINI is not set
 # BR2_PACKAGE_TMUX is not set
 # BR2_PACKAGE_TTYD is not set
+
+#
+# uuu needs a toolchain w/ C++14, threads, atomic, wchar
+#
 # BR2_PACKAGE_WTFUTIL is not set
 # BR2_PACKAGE_XMLSTARLET is not set
 # BR2_PACKAGE_XXHASH is not set
 # BR2_PACKAGE_YTREE is not set
+# BR2_PACKAGE_ZOXIDE is not set
 
 #
 # System tools
 #
 # BR2_PACKAGE_ACL is not set
+# BR2_PACKAGE_AMAZON_ECR_CREDENTIAL_HELPER is not set
 # BR2_PACKAGE_ANDROID_TOOLS is not set
 # BR2_PACKAGE_ATOP is not set
 # BR2_PACKAGE_ATTR is not set
@@ -3682,15 +3879,21 @@ BR2_PACKAGE_AUDIT_ARCH_SUPPORTS=y
 # BR2_PACKAGE_BALENA_ENGINE is not set
 # BR2_PACKAGE_BUBBLEWRAP is not set
 # BR2_PACKAGE_CGROUPFS_MOUNT is not set
+# BR2_PACKAGE_CGROUPFS_V2_MOUNT is not set
 
 #
 # circus needs Python 3 and a toolchain w/ C++, threads
 #
 # BR2_PACKAGE_CONMON is not set
 # BR2_PACKAGE_CONTAINERD is not set
+# BR2_PACKAGE_CONTAINERS_IMAGE_CONFIG is not set
 # BR2_PACKAGE_CPULIMIT is not set
 # BR2_PACKAGE_CPULOAD is not set
 BR2_PACKAGE_CRIU_ARCH_SUPPORTS=y
+
+#
+# criu needs a glibc or musl toolchain w/ threads, host gcc >= 7, gcc >= 8, headers >= 4.18, C++, dynamic library, wchar
+#
 # BR2_PACKAGE_CRUN is not set
 # BR2_PACKAGE_DAEMON is not set
 # BR2_PACKAGE_DC3DD is not set
@@ -3698,11 +3901,15 @@ BR2_PACKAGE_CRIU_ARCH_SUPPORTS=y
 #
 # ddrescue needs a toolchain w/ C++
 #
+# BR2_PACKAGE_DISTRIBUTION_REGISTRY is not set
 # BR2_PACKAGE_DOCKER_CLI is not set
+# BR2_PACKAGE_DOCKER_CLI_BUILDX is not set
 
 #
 # docker-compose needs docker-cli and a toolchain w/ threads
 #
+# BR2_PACKAGE_DOCKER_CREDENTIAL_ACR_ENV is not set
+# BR2_PACKAGE_DOCKER_CREDENTIAL_GCR is not set
 # BR2_PACKAGE_DOCKER_ENGINE is not set
 # BR2_PACKAGE_EARLYOOM is not set
 # BR2_PACKAGE_EFIBOOTMGR is not set
@@ -3718,6 +3925,7 @@ BR2_PACKAGE_EFIVAR_ARCH_SUPPORTS=y
 # BR2_PACKAGE_GETENT is not set
 # BR2_PACKAGE_GKRELLM is not set
 # BR2_PACKAGE_HTOP is not set
+# BR2_PACKAGE_HWCLOCK_INITSCRIPT is not set
 # BR2_PACKAGE_IBM_SW_TPM2 is not set
 BR2_PACKAGE_INITSCRIPTS=y
 
@@ -3732,6 +3940,7 @@ BR2_PACKAGE_INITSCRIPTS=y
 #
 # BR2_PACKAGE_KEYUTILS is not set
 # BR2_PACKAGE_KMOD is not set
+# BR2_PACKAGE_KMON is not set
 # BR2_PACKAGE_KVMTOOL is not set
 # BR2_PACKAGE_LIBOSTREE is not set
 BR2_PACKAGE_LIBVIRT_ARCH_SUPPORTS=y
@@ -3744,8 +3953,13 @@ BR2_PACKAGE_MAKEDUMPFILE_ARCH_SUPPORTS=y
 # BR2_PACKAGE_MAKEDUMPFILE is not set
 # BR2_PACKAGE_MENDER is not set
 # BR2_PACKAGE_MENDER_CONNECT is not set
+
+#
+# mender-update-modules needs mender
+#
 # BR2_PACKAGE_MFOC is not set
 # BR2_PACKAGE_MOBY_BUILDKIT is not set
+# BR2_PACKAGE_MOKUTIL is not set
 # BR2_PACKAGE_MONIT is not set
 
 #
@@ -3760,7 +3974,7 @@ BR2_PACKAGE_MAKEDUMPFILE_ARCH_SUPPORTS=y
 # BR2_PACKAGE_NUMACTL is not set
 
 #
-# nut needs a toolchain w/ C++
+# nut needs a toolchain w/ C++, threads
 #
 BR2_PACKAGE_OPENVMTOOLS_ARCH_SUPPORTS=y
 # BR2_PACKAGE_OPENVMTOOLS is not set
@@ -3772,10 +3986,11 @@ BR2_PACKAGE_OPENVMTOOLS_ARCH_SUPPORTS=y
 #
 # petitboot needs a toolchain w/ wchar, dynamic library, threads, udev /dev management
 #
+# BR2_PACKAGE_PODMAN is not set
 # BR2_PACKAGE_POLKIT is not set
-# BR2_PACKAGE_PROCRANK_LINUX is not set
 # BR2_PACKAGE_PROCS is not set
 # BR2_PACKAGE_PWGEN is not set
+# BR2_PACKAGE_QBEE_AGENT is not set
 # BR2_PACKAGE_QUOTA is not set
 # BR2_PACKAGE_QUOTATOOL is not set
 # BR2_PACKAGE_RAUC is not set
@@ -3790,7 +4005,7 @@ BR2_PACKAGE_OPENVMTOOLS_ARCH_SUPPORTS=y
 # BR2_PACKAGE_SCRYPT is not set
 
 #
-# sdbus-c++ needs systemd and a toolchain w/ C++, gcc >= 7
+# sdbus-c++ needs systemd and a toolchain w/ C++, gcc >= 8
 #
 
 #
@@ -3798,6 +4013,7 @@ BR2_PACKAGE_OPENVMTOOLS_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_SEATD is not set
 # BR2_PACKAGE_SHADOW is not set
+# BR2_PACKAGE_SKOPEO is not set
 # BR2_PACKAGE_SMACK is not set
 
 #
@@ -3824,18 +4040,20 @@ BR2_PACKAGE_XVISOR_ARCH_SUPPORTS=y
 # Text editors and viewers
 #
 # BR2_PACKAGE_BAT is not set
+# BR2_PACKAGE_BROOT is not set
+# BR2_PACKAGE_BVI is not set
 # BR2_PACKAGE_ED is not set
 # BR2_PACKAGE_JOE is not set
 # BR2_PACKAGE_MC is not set
 # BR2_PACKAGE_MG is not set
 # BR2_PACKAGE_MOST is not set
 # BR2_PACKAGE_NANO is not set
+# BR2_PACKAGE_NNN is not set
 # BR2_PACKAGE_UEMACS is not set
 
 #
 # Filesystem images
 #
-# BR2_TARGET_ROOTFS_AXFS is not set
 # BR2_TARGET_ROOTFS_BTRFS is not set
 # BR2_TARGET_ROOTFS_CLOOP is not set
 # BR2_TARGET_ROOTFS_CPIO is not set
@@ -3849,7 +4067,6 @@ BR2_PACKAGE_XVISOR_ARCH_SUPPORTS=y
 #
 # BR2_TARGET_ROOTFS_JFFS2 is not set
 # BR2_TARGET_ROOTFS_OCI is not set
-# BR2_TARGET_ROOTFS_ROMFS is not set
 # BR2_TARGET_ROOTFS_SQUASHFS is not set
 BR2_TARGET_ROOTFS_TAR=y
 BR2_TARGET_ROOTFS_TAR_NONE=y
@@ -3864,6 +4081,7 @@ BR2_TARGET_ROOTFS_TAR_OPTIONS=""
 # BR2_TARGET_ROOTFS_UBI is not set
 # BR2_TARGET_ROOTFS_UBIFS is not set
 # BR2_TARGET_ROOTFS_YAFFS2 is not set
+BR2_TARGET_XILINX_FIRMWARE_ARCH_SUPPORTS=y
 
 #
 # Bootloaders
@@ -3887,6 +4105,7 @@ BR2_PACKAGE_SHIM_ARCH_SUPPORTS=y
 # BR2_TARGET_TI_K3_R5_LOADER is not set
 # BR2_TARGET_UBOOT is not set
 # BR2_TARGET_VEXPRESS_FIRMWARE is not set
+# BR2_TARGET_XILINX_PREBUILT is not set
 
 #
 # Host utilities
@@ -3896,11 +4115,14 @@ BR2_PACKAGE_SHIM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_AGENT_PROXY is not set
 # BR2_PACKAGE_HOST_AMLOGIC_BOOT_FIP is not set
 # BR2_PACKAGE_HOST_ANDROID_TOOLS is not set
+BR2_PACKAGE_HOST_ARM_GNU_TOOLCHAIN_SUPPORTS=y
 # BR2_PACKAGE_HOST_ASN1C is not set
 # BR2_PACKAGE_HOST_BABELTRACE2 is not set
 # BR2_PACKAGE_HOST_BMAP_TOOLS is not set
+# BR2_PACKAGE_HOST_BMAP_WRITER is not set
 # BR2_PACKAGE_HOST_BOOTGEN is not set
 # BR2_PACKAGE_HOST_BTRFS_PROGS is not set
+# BR2_PACKAGE_HOST_CASYNC_NANO is not set
 # BR2_PACKAGE_HOST_CHECKPOLICY is not set
 # BR2_PACKAGE_HOST_CHECKSEC is not set
 # BR2_PACKAGE_HOST_CMAKE is not set
@@ -3933,11 +4155,19 @@ BR2_PACKAGE_HOST_FLUTTER_SDK_BIN_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_GENIMAGE is not set
 # BR2_PACKAGE_HOST_GENPART is not set
 # BR2_PACKAGE_HOST_GNUPG is not set
+# BR2_PACKAGE_HOST_GNUPG2 is not set
 BR2_PACKAGE_HOST_GO_TARGET_ARCH_SUPPORTS=y
 BR2_PACKAGE_HOST_GO_TARGET_CGO_LINKING_SUPPORTS=y
 BR2_PACKAGE_HOST_GO_HOST_ARCH_SUPPORTS=y
+BR2_PACKAGE_HOST_GO_HOST_CGO_LINKING_SUPPORTS=y
+# BR2_PACKAGE_HOST_GO is not set
+BR2_PACKAGE_PROVIDES_HOST_GO="host-go-bin"
+BR2_PACKAGE_HOST_GO_BIN_HOST_ARCH="amd64"
+BR2_PACKAGE_HOST_GO_BIN_HOST_ARCH_SUPPORTS=y
 BR2_PACKAGE_HOST_GO_BOOTSTRAP_STAGE1_ARCH_SUPPORTS=y
 BR2_PACKAGE_HOST_GO_BOOTSTRAP_STAGE2_ARCH_SUPPORTS=y
+BR2_PACKAGE_HOST_GO_BOOTSTRAP_STAGE3_ARCH_SUPPORTS=y
+BR2_PACKAGE_HOST_GO_BOOTSTRAP_STAGE4_ARCH_SUPPORTS=y
 BR2_PACKAGE_HOST_GOOGLE_BREAKPAD_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_GPTFDISK is not set
 # BR2_PACKAGE_HOST_IMAGEMAGICK is not set
@@ -3954,6 +4184,7 @@ BR2_PACKAGE_HOST_GOOGLE_BREAKPAD_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_MENDER_ARTIFACT is not set
 # BR2_PACKAGE_HOST_MESON_TOOLS is not set
 # BR2_PACKAGE_HOST_MICROCHIP_HSS_PAYLOAD_GENERATOR is not set
+# BR2_PACKAGE_HOST_MINISIGN is not set
 # BR2_PACKAGE_HOST_MKPASSWD is not set
 # BR2_PACKAGE_HOST_MOBY_BUILDKIT is not set
 # BR2_PACKAGE_HOST_MOSQUITTO is not set
@@ -3977,6 +4208,7 @@ BR2_PACKAGE_HOST_PATCHELF=y
 # BR2_PACKAGE_HOST_PYTHON_LXML is not set
 # BR2_PACKAGE_HOST_PYTHON_PYYAML is not set
 # BR2_PACKAGE_HOST_PYTHON_SIX is not set
+# BR2_PACKAGE_HOST_PYTHON_USWID is not set
 # BR2_PACKAGE_HOST_PYTHON_XLRD is not set
 # BR2_PACKAGE_HOST_PYTHON3 is not set
 BR2_PACKAGE_HOST_QEMU_ARCH_SUPPORTS=y
@@ -3998,10 +4230,14 @@ BR2_PACKAGE_PROVIDES_HOST_RUSTC="host-rust-bin"
 # BR2_PACKAGE_HOST_SDBUS_CPP is not set
 # BR2_PACKAGE_HOST_SDBUSPLUS is not set
 # BR2_PACKAGE_HOST_SENTRY_CLI is not set
+# BR2_PACKAGE_HOST_SKOPEO is not set
 # BR2_PACKAGE_HOST_SLOCI_IMAGE is not set
+# BR2_PACKAGE_HOST_SNAGBOOT is not set
 # BR2_PACKAGE_HOST_SQUASHFS is not set
 # BR2_PACKAGE_HOST_SWIG is not set
+# BR2_PACKAGE_HOST_SWTPM is not set
 # BR2_PACKAGE_HOST_SWUGENERATOR is not set
+# BR2_PACKAGE_HOST_TIPIDEE is not set
 # BR2_PACKAGE_HOST_UBOOT_TOOLS is not set
 # BR2_PACKAGE_HOST_UTIL_LINUX is not set
 # BR2_PACKAGE_HOST_UTP_COM is not set
@@ -4016,8 +4252,207 @@ BR2_PACKAGE_PROVIDES_HOST_RUSTC="host-rust-bin"
 #
 
 #
+# Legacy options removed in 2025.11
+#
+# BR2_KERNEL_HEADERS_5_4 is not set
+# BR2_PACKAGE_LIBARGTABLE2 is not set
+# BR2_PACKAGE_OLA is not set
+# BR2_PACKAGE_BATMAN_ADV_NC is not set
+# BR2_PACKAGE_DVBSNOOP is not set
+# BR2_PACKAGE_PROCRANK_LINUX is not set
+# BR2_PACKAGE_MONGREL2 is not set
+# BR2_PACKAGE_EXPECT is not set
+# BR2_PACKAGE_BCTOOLBOX is not set
+# BR2_PACKAGE_ORTP is not set
+# BR2_PACKAGE_MEDIASTREAMER is not set
+# BR2_PACKAGE_BELR is not set
+# BR2_PACKAGE_BELLE_SIP is not set
+# BR2_PACKAGE_LINPHONE is not set
+# BR2_PACKAGE_LIBJWT is not set
+# BR2_PACKAGE_RAMSPEED is not set
+# BR2_PACKAGE_LESSTIF is not set
+# BR2_KERNEL_HEADERS_6_16 is not set
+# BR2_PACKAGE_MURATA_CYW_FW_CYW4339_1CK is not set
+# BR2_PACKAGE_MURATA_CYW_FW_CYW4339_ZP is not set
+# BR2_PACKAGE_LIBBSON is not set
+# BR2_TARGET_ROOTFS_AXFS is not set
+# BR2_PACKAGE_LOGSURFER is not set
+# BR2_LINUX_KERNEL_EXT_FBTFT is not set
+# BR2_PACKAGE_DMENU_WAYLAND is not set
+# BR2_PACKAGE_SYLPHEED is not set
+# BR2_PACKAGE_PINENTRY_GTK2 is not set
+# BR2_PACKAGE_OPENCV4_WITH_GTK is not set
+# BR2_PACKAGE_OPENCV3_WITH_GTK is not set
+# BR2_PACKAGE_NETSURF_GTK is not set
+# BR2_PACKAGE_METACITY is not set
+# BR2_PACKAGE_LIBSEXY is not set
+# BR2_PACKAGE_LIBGLADE is not set
+# BR2_PACKAGE_LEAFPAD is not set
+# BR2_PACKAGE_GTKPERF is not set
+# BR2_PACKAGE_GTK2_ENGINES is not set
+# BR2_PACKAGE_GKRELLM_CLIENT is not set
+# BR2_PACKAGE_CWIID_WMGUI is not set
+# BR2_LINUX_KERNEL_EXT_AUFS is not set
+# BR2_PACKAGE_AUFS_UTIL is not set
+# BR2_TOOLCHAIN_EXTERNAL_LINARO_ARMEB is not set
+# BR2_TOOLCHAIN_EXTERNAL_LINARO_ARM is not set
+# BR2_TOOLCHAIN_EXTERNAL_LINARO_AARCH64_BE is not set
+# BR2_TOOLCHAIN_EXTERNAL_LINARO_AARCH64 is not set
+# BR2_TOOLCHAIN_EXTERNAL_CODESOURCERY_MIPS is not set
+# BR2_LINUX_KERNEL_EXT_EV3DEV_LINUX_DRIVERS is not set
+
+#
+# Legacy options removed in 2025.08
+#
+# BR2_PACKAGE_NETSTAT_NAT is not set
+# BR2_PACKAGE_LIGHTTPD_LIBEV is not set
+# BR2_PACKAGE_LIBSVGTINY is not set
+# BR2_PACKAGE_THTTPD is not set
+# BR2_KERNEL_HEADERS_6_15 is not set
+# BR2_PACKAGE_LIBCURL_BEARSSL is not set
+# BR2_PACKAGE_LIBOLM is not set
+# BR2_PACKAGE_LIBWEBSOCK is not set
+# BR2_TARGET_EDK2_PLATFORM_SOCIONEXT_DEVELOPERBOX is not set
+# BR2_PACKAGE_LIBEBUR128 is not set
+# BR2_KERNEL_HEADERS_6_14 is not set
+# BR2_PACKAGE_GPSD_OCEANSERVER is not set
+# BR2_PACKAGE_MESA3D_OSMESA_GALLIUM is not set
+# BR2_PACKAGE_ALSA_LIB_ALISP is not set
+
+#
+# Legacy options removed in 2025.05
+#
+# BR2_GCC_VERSION_12_X is not set
+# BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_SWRAST is not set
+# BR2_PACKAGE_MBEDTLS_COMPRESSION is not set
+# BR2_KERNEL_HEADERS_6_13 is not set
+# BR2_PACKAGE_MPD_SOUNDCLOUD is not set
+# BR2_PACKAGE_DOCKER_ENGINE_DOCKER_INIT is not set
+
+#
+# Legacy options removed in 2025.02
+#
+# BR2_PACKAGE_SQLITE_ENABLE_JSON1 is not set
+# BR2_PACKAGE_ANGULARJS is not set
+# BR2_PACKAGE_ANGULAR_WEBSOCKET is not set
+# BR2_PACKAGE_LATENCYTOP is not set
+# BR2_PACKAGE_OBSIDIAN_CURSORS is not set
+# BR2_PACKAGE_W_SCAN is not set
+# BR2_PACKAGE_GENROMFS is not set
+# BR2_TARGET_ROOTFS_ROMFS is not set
+# BR2_BINUTILS_VERSION_2_41_X is not set
+# BR2_TARGET_ROOTFS_EXT2_2r0 is not set
+# BR2_GDB_VERSION_13 is not set
+# BR2_nios2 is not set
+# BR2_TOOLCHAIN_EXTERNAL_BOOTLIN_NIOS2_GLIBC_BLEEDING_EDGE is not set
+# BR2_TOOLCHAIN_EXTERNAL_BOOTLIN_NIOS2_GLIBC_STABLE is not set
+# BR2_PACKAGE_DIRECTFB is not set
+# BR2_PACKAGE_GST_OMX is not set
+# BR2_PACKAGE_MIMIC is not set
+# BR2_PACKAGE_SDL2_DIRECTFB is not set
+# BR2_PACKAGE_SDL_DIRECTFB is not set
+# BR2_PACKAGE_QT5BASE_DIRECTFB is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_DIRECTFB is not set
+# BR2_PACKAGE_LITE is not set
+# BR2_PACKAGE_LINUX_FUSION is not set
+# BR2_PACKAGE_DIRECTFB_EXAMPLES is not set
+# BR2_PACKAGE_HIAWATHA is not set
+# BR2_PACKAGE_MONGODB is not set
+# BR2_PACKAGE_PYTHON_M2CRYPTO is not set
+# BR2_KERNEL_HEADERS_4_19 is not set
+# BR2_KERNEL_HEADERS_6_11 is not set
+# BR2_PACKAGE_GIBLIB is not set
+# BR2_PACKAGE_FCONFIG is not set
+# BR2_PACKAGE_LIBHID is not set
+# BR2_PACKAGE_QUAGGA is not set
+# BR2_PACKAGE_RAMSMP is not set
+
+#
+# Legacy options removed in 2024.11
+#
+# BR2_PACKAGE_BSDIFF is not set
+# BR2_PACKAGE_PROCPS_NS_ORIGINAL_TOP is not set
+# BR2_PACKAGE_QEMU_TARGET_NIOS2 is not set
+# BR2_PACKAGE_POPPERJS is not set
+# BR2_KERNEL_HEADERS_6_10 is not set
+BR2_PACKAGE_IPMITOOL_PEN_REG_URI=""
+# BR2_PACKAGE_ERLANG_P1_YAML is not set
+# BR2_PACKAGE_ERLANG_P1_XMPP is not set
+# BR2_PACKAGE_ERLANG_P1_XML is not set
+# BR2_PACKAGE_ERLANG_P1_STUN is not set
+# BR2_PACKAGE_FBV_GIF is not set
+# BR2_BINUTILS_VERSION_2_40_X is not set
+
+#
+# Legacy options removed in 2024.08
+#
+# BR2_PACKAGE_MIDORI is not set
+# BR2_PACKAGE_FROTZ is not set
+# BR2_PACKAGE_FAN_CTRL is not set
+# BR2_PACKAGE_FLUTTER_DYNAMIC_LAYOUTS_EXAMPLE is not set
+# BR2_KERNEL_HEADERS_6_9 is not set
+# BR2_x86_knightslanding is not set
+# BR2_x86_knightsmill is not set
+# BR2_PACKAGE_DVB_APPS is not set
+# BR2_PACKAGE_GAMIN is not set
+# BR2_PACKAGE_CAIRO_SVG is not set
+# BR2_PACKAGE_CAIRO_SCRIPT is not set
+# BR2_PACKAGE_CAIRO_PS is not set
+# BR2_PACKAGE_CAIRO_PDF is not set
+# BR2_PACKAGE_CAIRO_XML is not set
+# BR2_GDB_VERSION_12 is not set
+# BR2_TARGET_BEAGLEV_DDRINIT is not set
+# BR2_TARGET_BEAGLEV_SECONDBOOT is not set
+# BR2_PACKAGE_ONEVPL_INTEL_GPU is not set
+# BR2_PACKAGE_CGIC is not set
+# BR2_PACKAGE_BEECRYPT is not set
+# BR2_PACKAGE_VERSAL_FIRMWARE is not set
+# BR2_KERNEL_HEADERS_6_8 is not set
+# BR2_TARGET_AT91BOOTSTRAP is not set
+# BR2_TARGET_AT91DATAFLASHBOOT is not set
+# BR2_PACKAGE_ON2_8170_MODULES is not set
+# BR2_PACKAGE_ON2_8170_LIBS is not set
+# BR2_GCC_VERSION_11_X is not set
+# BR2_BINFMT_FLAT_SHARED is not set
+# BR2_PACKAGE_OMXPLAYER is not set
+# BR2_KERNEL_HEADERS_6_7 is not set
+# BR2_TARGET_TI_K3_IMAGE_GEN is not set
+# BR2_TARGET_UBOOT_NEEDS_TI_K3_DM is not set
+# BR2_PACKAGE_FLUTTER_GALLERY is not set
+# BR2_TOOLCHAIN_EXTERNAL_CODESCAPE_IMG_MIPS is not set
+# BR2_TOOLCHAIN_EXTERNAL_CODESCAPE_MTI_MIPS is not set
+# BR2_TOOLCHAIN_EXTERNAL_CODESOURCERY_AARCH64 is not set
+# BR2_TOOLCHAIN_EXTERNAL_CODESOURCERY_ARM is not set
+# BR2_BINUTILS_VERSION_2_39_X is not set
+
+#
+# Legacy options removed in 2024.02
+#
+# BR2_PACKAGE_MYSQL is not set
+# BR2_PACKAGE_ORACLE_MYSQL is not set
+# BR2_PACKAGE_STRONGSWAN_SCEP is not set
+# BR2_PACKAGE_SHADOW_UTMPX is not set
+# BR2_PACKAGE_TINYMEMBENCH is not set
+# BR2_PACKAGE_DAVINCI_BOOTCOUNT is not set
+# BR2_PACKAGE_PYTHON_CROSSBAR is not set
+# BR2_PACKAGE_PYTHON_PYGAME is not set
+# BR2_KERNEL_HEADERS_4_14 is not set
+# BR2_PACKAGE_LIBCAMERA_PIPELINE_RASPBERRYPI is not set
+# BR2_GDB_VERSION_11 is not set
+# BR2_PACKAGE_LIBMPD is not set
+# BR2_PACKAGE_GMPC is not set
+# BR2_PACKAGE_FLICKCURL is not set
+# BR2_PACKAGE_ONEVPL is not set
+# BR2_KERNEL_HEADERS_6_5 is not set
+BR2_PACKAGE_WATCHDOGD_GENERIC_POLL=0
+BR2_PACKAGE_WATCHDOGD_LOADAVG_POLL=0
+BR2_PACKAGE_WATCHDOGD_FILENR_POLL=0
+BR2_PACKAGE_WATCHDOGD_MEMINFO_POLL=0
+
+#
 # Legacy options removed in 2023.11
 #
+# BR2_PACKAGE_PYTHON_PYXB is not set
 # BR2_PACKAGE_OPENJDK_VERSION_11 is not set
 # BR2_KERNEL_HEADERS_6_4 is not set
 # BR2_PACKAGE_GOOGLE_MATERIAL_DESIGN_ICONS is not set
@@ -4129,7 +4564,6 @@ BR2_TARGET_ROOTFS_OCI_ENTRYPOINT_ARGS=""
 # BR2_PACKAGE_PYTHON_ENUM34 is not set
 # BR2_PACKAGE_PYTHON_ENUM is not set
 # BR2_PACKAGE_PYTHON_DIALOG is not set
-# BR2_PACKAGE_PYTHON_CONFIGOBJ is not set
 # BR2_PACKAGE_PYTHON_YIELDFROM is not set
 # BR2_PACKAGE_PYTHON_TYPING is not set
 # BR2_PACKAGE_PYTHON_SUBPROCESS32 is not set


### PR DESCRIPTION
Bumps buildroot version to use. This allows the buildroot gcc wrapper to support `-m64` which fixes the build issue cited in https://github.com/LemmyNet/lemmy/issues/6201#issuecomment-3657585011 using an image built from this PR.

`make oldconfig` is also run to get a good config otherwise some versions of the software built by buildroot are too old.